### PR TITLE
Phase 3: Blog infrastructure + first 5 articles

### DIFF
--- a/_data/blog-categories.yml
+++ b/_data/blog-categories.yml
@@ -1,0 +1,18 @@
+- slug: deep-dive
+  label_en: "Technical Deep-Dives"
+  label_uk: "Технічні огляди"
+- slug: case-study
+  label_en: "Case Studies"
+  label_uk: "Кейси"
+- slug: methodology
+  label_en: "Methodology"
+  label_uk: "Методологія"
+- slug: ai-practice
+  label_en: "AI Practice"
+  label_uk: "AI-практика"
+- slug: release-notes
+  label_en: "Release Notes"
+  label_uk: "Нотатки"
+- slug: thoughts
+  label_en: "Thoughts"
+  label_uk: "Думки"

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,9 +1,9 @@
 {% assign post = include.post %}
 {% assign cat_data = site.data.blog-categories | where: "slug", post.category | first %}
-{% if site.active_lang == 'uk' %}
-  {% assign category_label = cat_data.label_uk %}
+{% if cat_data %}
+  {% if site.active_lang == 'uk' %}{% assign category_label = cat_data.label_uk %}{% else %}{% assign category_label = cat_data.label_en %}{% endif %}
 {% else %}
-  {% assign category_label = cat_data.label_en %}
+  {% assign category_label = post.category %}
 {% endif %}
 
 <article class="post-card">
@@ -12,7 +12,7 @@
     {% if post.category and cat_data %}
     <span class="category-pill category-pill--{{ post.category }}">{{ category_label }}</span>
     {% endif %}
-    <span class="reading-time">{{ post.content | number_of_words | divided_by: 200 | plus: 1 }} {% if site.active_lang == 'uk' %}хв{% else %}min{% endif %}</span>
+    <span class="reading-time">{{ post.content | number_of_words | plus: 199 | divided_by: 200 }} {% if site.active_lang == 'uk' %}хв{% else %}min{% endif %}</span>
   </div>
   <h3 class="post-card__title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
   <p class="post-card__excerpt">{{ post.excerpt | strip_html | truncate: 160 }}</p>

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,0 +1,22 @@
+{% assign post = include.post %}
+{% assign cat_data = site.data.blog-categories | where: "slug", post.category | first %}
+{% if site.active_lang == 'uk' %}
+  {% assign category_label = cat_data.label_uk %}
+{% else %}
+  {% assign category_label = cat_data.label_en %}
+{% endif %}
+
+<article class="post-card">
+  <div class="post-card__meta">
+    <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+    {% if post.category and cat_data %}
+    <span class="category-pill category-pill--{{ post.category }}">{{ category_label }}</span>
+    {% endif %}
+    <span class="reading-time">{{ post.content | number_of_words | divided_by: 200 | plus: 1 }} {% if site.active_lang == 'uk' %}хв{% else %}min{% endif %}</span>
+  </div>
+  <h3 class="post-card__title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+  <p class="post-card__excerpt">{{ post.excerpt | strip_html | truncate: 160 }}</p>
+  {% if post.tags and post.tags.size > 0 %}
+  <div class="tag-list">{% for t in post.tags limit: 4 %}<span class="tag">{{ t }}</span>{% endfor %}</div>
+  {% endif %}
+</article>

--- a/_layouts/blog-category.html
+++ b/_layouts/blog-category.html
@@ -2,8 +2,10 @@
 layout: default
 ---
 {% assign cat_data = site.data.blog-categories | where: "slug", page.category | first %}
-{% assign cat_label = cat_data.label_en %}
-{% if site.active_lang == 'uk' %}{% assign cat_label = cat_data.label_uk %}{% endif %}
+{% assign cat_label = page.title | default: page.category %}
+{% if cat_data %}
+  {% if site.active_lang == 'uk' %}{% assign cat_label = cat_data.label_uk %}{% else %}{% assign cat_label = cat_data.label_en %}{% endif %}
+{% endif %}
 
 <!-- Page band -->
 <div style="background: var(--brand-green); color: white; padding-block: var(--sp-8); text-align: center;">

--- a/_layouts/blog-category.html
+++ b/_layouts/blog-category.html
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+{% assign cat_data = site.data.blog-categories | where: "slug", page.category | first %}
+{% assign cat_label = cat_data.label_en %}
+{% if site.active_lang == 'uk' %}{% assign cat_label = cat_data.label_uk %}{% endif %}
+
+<!-- Page band -->
+<div style="background: var(--brand-green); color: white; padding-block: var(--sp-8); text-align: center;">
+  <div class="container">
+    <h1 style="color:white; margin:0 0 var(--sp-3) 0;">{{ cat_label }}</h1>
+    <p style="color:rgba(255,255,255,0.85); max-width:55ch; margin-inline:auto; margin-bottom:0;">
+      {% if site.active_lang == 'uk' %}Думки про Go, отримання даних, AI-інструменти та фриланс-розробку.{% else %}Thoughts on Go, data extraction, AI tooling, and freelance engineering.{% endif %}
+    </p>
+  </div>
+</div>
+
+<div class="container section">
+  <!-- Category filter row -->
+  <div class="category-filter">
+    <a href="{{ '/blog/' | relative_url }}">
+      {% if site.active_lang == 'uk' %}Усі{% else %}All{% endif %}
+    </a>
+    {% for cat in site.data.blog-categories %}
+    <a href="{{ '/blog/categories/' | append: cat.slug | append: '/' | relative_url }}"{% if cat.slug == page.category %} class="active"{% endif %}>
+      {% if site.active_lang == 'uk' %}{{ cat.label_uk }}{% else %}{{ cat.label_en }}{% endif %}
+    </a>
+    {% endfor %}
+  </div>
+
+  <!-- Filtered post list -->
+  {% assign cat_posts = site.posts | where: "category", page.category %}
+  {% if cat_posts.size > 0 %}
+    {% for post in cat_posts %}
+    {% include post-card.html post=post %}
+    {% endfor %}
+  {% else %}
+  <p class="projects-intro">{% if site.active_lang == 'uk' %}У цій категорії ще немає публікацій.{% else %}No posts in this category yet.{% endif %}</p>
+  {% endif %}
+</div>

--- a/_layouts/blog-index.html
+++ b/_layouts/blog-index.html
@@ -21,7 +21,7 @@ layout: default
 <div class="container section">
   <!-- Category filter row -->
   <div class="category-filter">
-    <a href="{{ '/blog/' | relative_url }}"{% if page.url == '/blog/' or page.url == '/blog/index.html' %} class="active"{% endif %}>
+    <a href="{{ '/blog/' | relative_url }}"{% if page.url == '/blog/' or page.url == '/uk/blog/' %} class="active"{% endif %}>
       {% if site.active_lang == 'uk' %}Усі{% else %}All{% endif %}
     </a>
     {% for cat in site.data.blog-categories %}

--- a/_layouts/blog-index.html
+++ b/_layouts/blog-index.html
@@ -1,0 +1,42 @@
+---
+layout: default
+---
+<!-- Page band -->
+<div style="background: var(--brand-green); color: white; padding-block: var(--sp-8); text-align: center;">
+  <div class="container">
+    {% if site.active_lang == 'uk' %}
+    <h1 style="color:white; margin:0 0 var(--sp-3) 0;">Блог</h1>
+    <p style="color:rgba(255,255,255,0.85); max-width:55ch; margin-inline:auto; margin-bottom:0;">
+      Думки про Go, отримання даних, AI-інструменти та фриланс-розробку.
+    </p>
+    {% else %}
+    <h1 style="color:white; margin:0 0 var(--sp-3) 0;">Blog</h1>
+    <p style="color:rgba(255,255,255,0.85); max-width:55ch; margin-inline:auto; margin-bottom:0;">
+      Thoughts on Go, data extraction, AI tooling, and freelance engineering.
+    </p>
+    {% endif %}
+  </div>
+</div>
+
+<div class="container section">
+  <!-- Category filter row -->
+  <div class="category-filter">
+    <a href="{{ '/blog/' | relative_url }}"{% if page.url == '/blog/' or page.url == '/blog/index.html' %} class="active"{% endif %}>
+      {% if site.active_lang == 'uk' %}Усі{% else %}All{% endif %}
+    </a>
+    {% for cat in site.data.blog-categories %}
+    <a href="{{ '/blog/categories/' | append: cat.slug | append: '/' | relative_url }}">
+      {% if site.active_lang == 'uk' %}{{ cat.label_uk }}{% else %}{{ cat.label_en }}{% endif %}
+    </a>
+    {% endfor %}
+  </div>
+
+  <!-- Post list -->
+  {% if site.posts.size > 0 %}
+    {% for post in site.posts %}
+    {% include post-card.html post=post %}
+    {% endfor %}
+  {% else %}
+  <p class="projects-intro">{% if site.active_lang == 'uk' %}Публікацій ще немає. Заходьте пізніше!{% else %}No posts yet. Check back soon!{% endif %}</p>
+  {% endif %}
+</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -72,6 +72,30 @@ layout: default
   </div>
 </section>
 
+<!-- Latest Writing -->
+{% if site.posts.size > 0 %}
+<section class="home-blog" aria-labelledby="blog-heading">
+  <div class="container">
+    <div class="section-heading">
+      {% if site.active_lang == 'uk' %}
+      <h2 id="blog-heading">Останні статті</h2>
+      <p>Нотатки про Go, витягання даних, AI-інструменти та фріланс.</p>
+      {% else %}
+      <h2 id="blog-heading">Latest Writing</h2>
+      <p>Notes on Go, data extraction, AI tooling, and freelance engineering.</p>
+      {% endif %}
+    </div>
+    {% assign recent_posts = site.posts | limit: 3 %}
+    {% for post in recent_posts %}
+    {% include post-card.html post=post %}
+    {% endfor %}
+    <div style="text-align:center; margin-top: var(--sp-7);">
+      <a href="{{ '/blog/' | relative_url }}" class="btn btn--outline">{% if site.active_lang == 'uk' %}Всі статті →{% else %}All Posts →{% endif %}</a>
+    </div>
+  </div>
+</section>
+{% endif %}
+
 <!-- CTA -->
 <section class="home-cta" aria-labelledby="cta-heading">
   <div class="container">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,73 @@
+---
+layout: default
+---
+<div class="container section">
+  <!-- Breadcrumb -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="{{ '/' | relative_url }}">{% if site.active_lang == 'uk' %}Головна{% else %}Home{% endif %}</a>
+    <span class="sep" aria-hidden="true">›</span>
+    <a href="{{ '/blog/' | relative_url }}">{% if site.active_lang == 'uk' %}Блог{% else %}Blog{% endif %}</a>
+    <span class="sep" aria-hidden="true">›</span>
+    <span aria-current="page">{{ page.title }}</span>
+  </nav>
+
+  <!-- Post header -->
+  <header class="post-header">
+    <h1>{{ page.title }}</h1>
+    <div class="post-meta">
+      <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+
+      {% if page.category %}
+        {% assign cat_data = site.data.blog-categories | where: "slug", page.category | first %}
+        <a href="{{ '/blog/categories/' | append: page.category | append: '/' | relative_url }}" class="category-pill category-pill--{{ page.category }}">
+          {% if site.active_lang == 'uk' %}{{ cat_data.label_uk }}{% else %}{{ cat_data.label_en }}{% endif %}
+        </a>
+      {% endif %}
+
+      <span class="reading-time">{{ content | number_of_words | divided_by: 200 | plus: 1 }}{% if site.active_lang == 'uk' %} хв читання{% else %} min read{% endif %}</span>
+
+      {% include lang-switcher.html %}
+    </div>
+  </header>
+
+  <!-- Post body -->
+  <article class="post-body">
+    {{ content }}
+  </article>
+
+  <!-- Tags -->
+  {% if page.tags and page.tags.size > 0 %}
+  <div class="post-tags">
+    <strong>{% if site.active_lang == 'uk' %}Теги{% else %}Tags{% endif %}:</strong>
+    <div class="tag-list">
+      {% for t in page.tags %}
+      <a href="{{ '/blog/tags/' | append: t | append: '/' | relative_url }}" class="tag">{{ t }}</a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Post navigation -->
+  {% if page.previous or page.next %}
+  <nav class="post-nav" aria-label="Post navigation">
+    <div class="post-nav__prev">
+      {% if page.previous %}
+      <span>{% if site.active_lang == 'uk' %}← Попередня{% else %}← Previous{% endif %}</span>
+      <a href="{{ page.previous.url | relative_url }}">
+        {{ page.previous.title }}<br>
+        <time datetime="{{ page.previous.date | date_to_xmlschema }}">{{ page.previous.date | date: "%B %-d, %Y" }}</time>
+      </a>
+      {% endif %}
+    </div>
+    <div class="post-nav__next">
+      {% if page.next %}
+      <span>{% if site.active_lang == 'uk' %}Наступна →{% else %}Next →{% endif %}</span>
+      <a href="{{ page.next.url | relative_url }}">
+        {{ page.next.title }}<br>
+        <time datetime="{{ page.next.date | date_to_xmlschema }}">{{ page.next.date | date: "%B %-d, %Y" }}</time>
+      </a>
+      {% endif %}
+    </div>
+  </nav>
+  {% endif %}
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,11 +20,11 @@ layout: default
       {% if page.category %}
         {% assign cat_data = site.data.blog-categories | where: "slug", page.category | first %}
         <a href="{{ '/blog/categories/' | append: page.category | append: '/' | relative_url }}" class="category-pill category-pill--{{ page.category }}">
-          {% if site.active_lang == 'uk' %}{{ cat_data.label_uk }}{% else %}{{ cat_data.label_en }}{% endif %}
+          {% if cat_data %}{% if site.active_lang == 'uk' %}{{ cat_data.label_uk }}{% else %}{{ cat_data.label_en }}{% endif %}{% else %}{{ page.category }}{% endif %}
         </a>
       {% endif %}
 
-      <span class="reading-time">{{ content | number_of_words | divided_by: 200 | plus: 1 }}{% if site.active_lang == 'uk' %} хв читання{% else %} min read{% endif %}</span>
+      <span class="reading-time">{{ content | number_of_words | plus: 199 | divided_by: 200 }}{% if site.active_lang == 'uk' %} хв читання{% else %} min read{% endif %}</span>
 
       {% include lang-switcher.html %}
     </div>
@@ -41,7 +41,7 @@ layout: default
     <strong>{% if site.active_lang == 'uk' %}Теги{% else %}Tags{% endif %}:</strong>
     <div class="tag-list">
       {% for t in page.tags %}
-      <a href="{{ '/blog/tags/' | append: t | append: '/' | relative_url }}" class="tag">{{ t }}</a>
+      <a href="{{ '/blog/tags/' | relative_url }}#{{ t | slugify }}" class="tag">{{ t }}</a>
       {% endfor %}
     </div>
   </div>

--- a/_posts/2026-02-15-jekyll-polyglot-github-pages.md
+++ b/_posts/2026-02-15-jekyll-polyglot-github-pages.md
@@ -1,0 +1,119 @@
+---
+layout: post
+title: "Jekyll + Polyglot on GitHub Pages: What Actually Works in 2026"
+date: 2026-02-15
+permalink: /blog/2026/02/15/jekyll-polyglot-github-pages/
+category: thoughts
+tags: [jekyll, polyglot, github-actions, i18n, github-pages]
+lang: en
+description: "Practical notes from migrating a Jekyll site to jekyll-polyglot with GitHub Actions — the static_href trick, gitignore gotchas, and what the docs don't tell you."
+excerpt: "I spent more time than I should have getting jekyll-polyglot working correctly on GitHub Pages. The issues were not conceptually hard, but each one was invisible until it bit me. These are the notes I wished existed when I started."
+---
+
+I spent more time than I should have getting jekyll-polyglot working correctly on GitHub Pages. The issues were not conceptually hard, but each one was invisible until it bit me. These are the notes I wished existed when I started.
+
+## GitHub Pages Will Not Run Polyglot
+
+GitHub Pages maintains a whitelist of allowed Jekyll plugins. `jekyll-polyglot` is not on it. If you add it to your `_plugins/` directory or `Gemfile` and push, GitHub Pages will silently build without it — no error, just a site with no language support and some broken links.
+
+The fix is to take the build out of GitHub Pages entirely and use GitHub Actions to build and deploy:
+
+```yaml
+# .github/workflows/deploy.yml
+name: Deploy Jekyll site
+on:
+  push:
+    branches: [main]
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - run: bundle exec jekyll build
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+```
+
+The `peaceiris/actions-gh-pages` action pushes `_site/` contents to the `gh-pages` branch, which GitHub Pages serves as a static host. You lose the simplicity of push-to-deploy, but you gain full plugin support.
+
+## The URL Rewriting Surprise
+
+Polyglot's core feature is rewriting URLs on non-default-language pages so that `/about/` becomes `/uk/about/` when building the Ukrainian version. This happens automatically for all root-relative hrefs in your HTML output.
+
+The surprise: this includes your language switcher.
+
+If your language switcher has a link like `<a href="/about/">English</a>`, polyglot will rewrite it to `/uk/about/` on the Ukrainian page — which means clicking "English" keeps you in Ukrainian. A self-link, invisibly.
+
+The fix is `static_href`:
+
+{% raw %}
+```html
+{% static_href %}href="/about/"{% endstatic_href %}
+```
+{% endraw %}
+
+Polyglot sees this tag and leaves the URL alone regardless of which language page is being built. It is not pretty Liquid, but it is the correct tool for links that must not be localized.
+
+## `data-no-localization` Does Not Work for Relative URLs
+
+The polyglot docs mention a `data-no-localization` attribute that is supposed to prevent URL rewriting on specific elements. In practice, this works for absolute URLs (`https://...`) but not for root-relative URLs (`/path/to/page`). The rewriting logic does not check for this attribute on relative href values.
+
+This is not a bug in your configuration. Use `static_href` tags for language switcher links. Do not spend an afternoon tweaking `data-no-localization` attributes.
+
+## Gemfile and Git
+
+Many Jekyll project templates list `Gemfile.lock` in `.gitignore` but do not track `Gemfile` at all — the assumption being that the Gemfile is "obvious" local configuration. This breaks badly when you add GitHub Actions to your build, because the Actions runner starts fresh with no Gemfile.
+
+Make sure both `Gemfile` and `Gemfile.lock` are committed:
+
+```bash
+git add Gemfile Gemfile.lock
+git commit -m "Track Gemfile and lock for CI"
+```
+
+The `Gemfile.lock` pin ensures the Actions runner uses exactly the same gem versions you tested locally, which prevents the "works on my machine, fails in CI" failure mode.
+
+## The Global Gitignore Trap
+
+This one took an embarrassingly long time to diagnose. My global `~/.gitignore_global` included the pattern `_*`, which I had added years ago to ignore scratch directories prefixed with underscores.
+
+Jekyll's content directories are all prefixed with underscores: `_layouts/`, `_includes/`, `_data/`, `_posts/`, `_sass/`. All of them matched the global ignore pattern. Git would not track them.
+
+`git status` showed a clean working tree. `git add _layouts/` silently did nothing. The site built locally because the files existed on disk; it failed in CI because they were never committed.
+
+The fix is explicit negation in the project's `.gitignore`:
+
+```gitignore
+# Undo global _* ignore for Jekyll directories
+!_layouts/
+!_includes/
+!_data/
+!_posts/
+!_sass/
+!_config.yml
+```
+
+Alternatively, remove the `_*` pattern from your global gitignore if you do not actually need it. I kept the project-level negation because other machines might have the same global pattern.
+
+## One More: Exclude Directories from Localization
+
+By default, polyglot will try to localize everything, including your `assets/` directory. This produces duplicate copies of your CSS and images under `/uk/assets/`, which is wasteful and can cause caching issues.
+
+Add explicit exclusions in `_config.yml`:
+
+```yaml
+exclude_from_localization:
+  - assets
+  - robots.txt
+  - sitemap.xml
+```
+
+Polyglot will leave these paths alone when building non-default language versions.
+
+Once all these pieces are in place, the polyglot setup is genuinely clean: one source file per piece of content, `lang:` in the front matter, and the plugin handles the rest. Getting to that point just requires knowing where the traps are.

--- a/_posts/2026-03-01-vibe-coding-methodology.md
+++ b/_posts/2026-03-01-vibe-coding-methodology.md
@@ -1,0 +1,69 @@
+---
+layout: post
+title: "Vibe Coding Without Vibes: Keeping Engineering Standards While Using AI"
+date: 2026-03-01
+permalink: /blog/2026/03/01/vibe-coding-methodology/
+category: methodology
+tags: [ai, methodology, vibe-coding, claude, cursor]
+lang: en
+description: "Why AI-assisted development needs the same engineering discipline as hand-written code — and the practices that keep it maintainable."
+excerpt: "Vibe coding — the practice of describing what you want and letting an AI generate the implementation — is real and productive. It is also a reliable way to accumulate technical debt at AI speed if you treat the AI as a replacement for engineering discipline rather than an accelerant."
+---
+
+Vibe coding — the practice of describing what you want and letting an AI generate the implementation — is real and productive. It is also a reliable way to accumulate technical debt at AI speed if you treat the AI as a replacement for engineering discipline rather than an accelerant.
+
+The issue is not the AI. The issue is that the habits that make hand-written code maintainable do not enforce themselves just because you switched to prompted code.
+
+## YAGNI Still Applies
+
+AI models are trained to be helpful. When you ask for a user authentication system, a helpful model will often give you authentication plus password reset, plus session management, plus an admin flag on the user model, plus email verification — because those things often go together and the model is pattern-matching on codebases where they do.
+
+This is YAGNI violation at generation speed. You did not ask for those things, you do not need them yet, and now they are in your codebase requiring maintenance, testing, and decision-making.
+
+The fix is specificity in prompts. "Implement JWT authentication — just the middleware that validates a token and sets a context value, nothing else" produces a dramatically different result than "implement authentication."
+
+## Specs Before Code
+
+The most productive use of AI in development is not asking it to figure out what to build. It is asking it to build a thing you have already figured out. This means writing a spec first.
+
+A spec does not need to be elaborate. For a single task it might be four bullet points:
+
+```
+- Accept a POST /webhooks/stripe body
+- Validate the Stripe-Signature header using STRIPE_WEBHOOK_SECRET from env
+- On payment_intent.succeeded, call OrderService.MarkPaid(paymentIntentID)
+- Return 200 on success, 400 on invalid signature, 500 on internal error
+```
+
+That spec constrains the AI to what you actually want. Without it, the model will make choices — about error handling, about what to log, about whether to add a retry queue — and some of those choices will be wrong for your context.
+
+## Review Still Matters
+
+AI output requires the same code review scrutiny as output from a junior developer. The AI does not know your conventions, your security model, or what you decided last sprint. It knows common patterns, which is not the same thing.
+
+Things to specifically look for in AI-generated code:
+
+- **Invented abstractions.** A function that was supposed to fetch a user instead returns a result type with three fields, two of which you did not ask for and one of which shadows a name in an outer scope.
+- **Inconsistent error handling.** The happy path is fine; the AI often gets bored with error handling and uses a different pattern for the third error case.
+- **Missing input validation.** AI will validate inputs that appear in its training data for similar functions. It will skip validation for inputs that seem "internal" to the application.
+- **Silent failure modes.** Goroutines that panic without recovery, channels that can deadlock, contexts that are not propagated.
+
+## The Subagent Pattern
+
+One long conversation with an AI is a trap. The model's context window fills with earlier decisions, and later outputs are implicitly constrained by them — including bad decisions made early that were never corrected.
+
+The subagent pattern: one task, one fresh context, one review. Isolate each task into a focused prompt that includes everything the AI needs and nothing it does not. This produces more predictable output and makes it easier to review because the scope is bounded.
+
+In practice this means using `git worktrees` per task and invoking a new Claude Code session per worktree. The overhead is low; the predictability gain is significant.
+
+## When Not to Use AI
+
+There are categories of code where AI assistance is actively harmful:
+
+**Security-sensitive code.** Authentication flows, cryptographic operations, access control checks. These require getting the exact right thing right the first time. AI will produce plausible-looking code that has subtle flaws — timing attacks, missing validation in edge cases, incorrect use of a crypto primitive. Read the spec, implement it yourself, have a second human review it.
+
+**Novel algorithms.** If the algorithm you need does not exist in common form in AI training data, the AI will approximate it with something that looks similar but is not correct. This is the worst failure mode: code that looks right, passes obvious tests, and fails in production on edge cases.
+
+**Regulatory compliance logic.** Tax calculations, GDPR right-to-erasure implementation, financial rounding rules. The consequences of getting these wrong are not a debugging session; they are legal or financial exposure. Understand the spec yourself.
+
+AI is a genuine productivity multiplier for the large majority of implementation work that is routine. The discipline is knowing which parts are not routine.

--- a/_posts/2026-03-15-keepincrm-automation.md
+++ b/_posts/2026-03-15-keepincrm-automation.md
@@ -1,0 +1,89 @@
+---
+layout: post
+title: "Automating KeepinCRM: From Manual Order Tracking to Zero-Touch Fulfillment"
+date: 2026-03-15
+permalink: /blog/2026/03/15/keepincrm-automation/
+category: case-study
+tags: [go, crm, automation, nova-poshta, telegram]
+lang: en
+description: "How a Go daemon watches Nova Poshta parcel statuses, moves CRM deals automatically, generates fiscal receipts, and sends SMS notifications."
+excerpt: "The client runs a small e-commerce operation — handmade goods, 50 to 80 orders on a busy day. Every morning started the same way: open Nova Poshta, check each tracking number, open KeepinCRM, move each deal to the matching stage. Forty-five minutes, every day, on a task a machine should own."
+---
+
+The client runs a small e-commerce operation — handmade goods, 50 to 80 orders on a busy day. Every morning started the same way: open Nova Poshta, check each tracking number, open KeepinCRM, move each deal to the matching stage. Forty-five minutes, every day, on a task a machine should own.
+
+## The Problem
+
+Manual order tracking at that volume is not just tedious — it is error-prone. Missed status changes meant delayed follow-ups. Parcels returned to sender because nobody noticed the "storage expires in 2 days" status until day three. Fiscal receipts were generated manually after confirmation of delivery, which sometimes meant forgetting entirely.
+
+The client had KeepinCRM configured with deal stages that mapped directly to parcel lifecycle states: `Shipped`, `In Transit`, `Awaiting Pickup`, `Delivered`, `Return Initiated`, `Returned`. The mapping was clear. The problem was that someone had to perform it manually, twice a day.
+
+## The Solution
+
+A Go daemon running on a small VPS, polling Nova Poshta's tracking API every 30 minutes and driving a pipeline of three downstream actions.
+
+### Stage 1: Nova Poshta Polling
+
+Nova Poshta provides a JSON API for tracking. The daemon maintains a SQLite table of active tracking numbers with their last known status. On each poll cycle:
+
+```go
+statuses, err := np.GetTrackingStatuses(ctx, activeTTNs)
+for _, s := range statuses {
+    if s.StatusCode != cache.Get(s.TTN) {
+        events <- TrackingEvent{TTN: s.TTN, OldStatus: cache.Get(s.TTN), NewStatus: s.StatusCode}
+        cache.Set(s.TTN, s.StatusCode)
+    }
+}
+```
+
+Nova Poshta's status codes are numeric. The daemon maps them to KeepinCRM stage names via a config file — the client can adjust the mapping without a code change.
+
+### Stage 2: KeepinCRM Pipeline
+
+KeepinCRM has a REST API for deal management. When a tracking event arrives, the daemon finds the deal associated with that tracking number (stored at deal creation time as a custom field) and moves it to the target stage:
+
+```go
+dealID, err := crm.FindDealByTTN(ctx, event.TTN)
+if err != nil { log.Error(...); continue }
+err = crm.MoveDeal(ctx, dealID, stageMap[event.NewStatus])
+```
+
+If `FindDealByTTN` returns nothing — the deal was closed, archived, or the TTN was entered incorrectly — the event is logged and a Telegram message is sent to the client's ops chat. No silent failures.
+
+### Stage 3: Fiscal Receipts via Checkbox
+
+Ukraine requires fiscal receipts for retail sales. The client was using Checkbox, which has an API for programmatic receipt generation. When a deal moves to `Delivered`, the daemon fetches the deal's line items from KeepinCRM and fires a receipt creation request to Checkbox:
+
+```go
+if event.NewStatus == StatusDelivered {
+    items, err := crm.GetDealLineItems(ctx, dealID)
+    receiptID, err := checkbox.CreateReceipt(ctx, items, deal.CustomerPhone)
+    crm.AddNote(ctx, dealID, "Fiscal receipt: "+receiptID)
+}
+```
+
+The receipt ID is written back to KeepinCRM as a deal note. The client can pull it up immediately if a customer asks.
+
+### Stage 4: TurboSMS Notification
+
+The final step sends an SMS to the customer when the parcel status changes to `Awaiting Pickup` — the most time-sensitive notification, since Nova Poshta storage is limited to five business days.
+
+TurboSMS has a straightforward HTTP API. The message template is configurable:
+
+```
+Your order #{order_id} is waiting at {branch_address}. 
+Storage until {expiry_date}. Track: https://novaposhta.ua/tracking/#{ttn}
+```
+
+The branch address and storage expiry date come from the Nova Poshta tracking response.
+
+## Results
+
+After two weeks of running in parallel with manual tracking (to validate correctness), the client switched to fully automated operation:
+
+- **Zero manual deal moves** since go-live. The daemon processes 150–200 tracking events per day.
+- **Fiscal receipts generated automatically** for every delivered order. Previously, about 15% were missed or delayed.
+- **Approximately 2 hours per day recovered** — the morning tracking session and an afternoon check-in that were both eliminated.
+- **Two return-to-sender events caught early** in the first month that would have been missed under the manual process.
+
+The daemon has been running for four months. The only operational intervention was a Nova Poshta API schema change that broke status code parsing for three hours — caught via Telegram alert, fixed with a config update, no data loss.

--- a/_posts/2026-04-01-claude-code-freelance-workflow.md
+++ b/_posts/2026-04-01-claude-code-freelance-workflow.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title: "Claude Code in Freelance: How I Ship Faster Without Cutting Corners"
+date: 2026-04-01
+permalink: /blog/2026/04/01/claude-code-freelance-workflow/
+category: ai-practice
+tags: [claude-code, ai, workflow, freelance]
+lang: en
+description: "How I integrated Claude Code's subagent-driven development into real freelance projects — concrete workflow, lessons, and tradeoffs."
+excerpt: "Six months ago I started using Claude Code as a primary development tool on client work. Not as an autocomplete or a rubber duck, but as a structured part of a repeatable workflow. Here is what that actually looks like in practice."
+---
+
+Six months ago I started using Claude Code as a primary development tool on client work. Not as an autocomplete or a rubber duck, but as a structured part of a repeatable workflow. Here is what that actually looks like in practice — with the warts included.
+
+## The Workflow in Four Stages
+
+**Stage 1: Planning.** Before any code is written I produce a spec. Not a vague description — a numbered task list with acceptance criteria per task. Claude Code can operate well on a clear task, and it operates poorly on a hazy one. This stage is still 100% human; the AI has no place here until you know what you want.
+
+**Stage 2: Worktrees.** Each task gets its own Git worktree (`git worktree add`). This is the part most people skip, and skipping it is why AI-assisted projects turn into spaghetti. Worktrees give each subagent a clean checkout with no side effects from other in-flight tasks.
+
+**Stage 3: Subagent-driven development.** I invoke Claude Code in each worktree with a tightly scoped prompt: one task, one context window, one outcome. The context isolation is not a limitation — it is the feature. A subagent that cannot see the rest of your codebase cannot make assumptions about it. That forces the prompt to be complete.
+
+**Stage 4: Two-stage review.** Every task gets reviewed twice. First pass: does the implementation match the spec? Second pass: code quality — naming, complexity, whether anything was invented that was not asked for (YAGNI violations are common in AI output). I use GitHub Copilot's PR review for the second pass and have Claude Code apply the fixes. The combination works well: Copilot flags issues, Claude Code fixes them without arguing.
+
+## A Real Example: valpere.github.io Phase 1
+
+My own site rebuild had 11 defined tasks — layout system, SCSS override, polyglot integration, portfolio pages, project pages, and so on. Each task was one worktree, one subagent invocation, one PR. Total wall-clock time across 11 tasks was roughly three days of calendar time, with maybe four hours of active human attention.
+
+Two tasks that looked simple turned out to need careful prompting:
+
+- **SCSS override for Minima.** Minima injects its own `assets/main.scss` via the gem. If your project also has `assets/main.scss`, Jekyll uses yours — but only if it has the right `@import` statements. The gotcha: the generated `_site/assets/main.scss` was empty on first run because the subagent created the file without importing anything. The fix was trivial once diagnosed, but the subagent had no way to know Minima's convention without being told.
+
+- **Polyglot language switcher.** `jekyll-polyglot` rewrites root-relative hrefs on non-default language pages. A language switcher that links to `/about/` will rewrite to `/uk/about/` when rendering the Ukrainian version — including the link that is supposed to stay on the same page. The solution is `static_href` Liquid tags, which polyglot explicitly skips. But the subagent used standard `<a href>` because that is the obvious thing to do. The prompt needed to say "use static_href for the language switcher links" explicitly.
+
+## The Copilot + Claude Combination
+
+GitHub Copilot's PR review is good at catching style issues and potential bugs in isolation. Claude Code is good at applying fixes in context. Running both on every PR takes maybe ten extra minutes per task and has caught real problems — duplicate logic, missing error handling, and one case where the subagent added a configuration option nobody asked for.
+
+## The Real Gotchas
+
+The most painful non-code issue: my global `~/.gitignore_global` had an `_*` pattern to ignore scratch directories. Jekyll's `_layouts/`, `_includes/`, `_data/`, and `_posts/` all match that pattern. The worktrees looked clean but were missing critical directories. This took about an hour to diagnose because `git status` showed nothing wrong — the files were not untracked, they were invisible.
+
+## The Tradeoff
+
+Subagents need precise prompts. That is both the cost and the discipline. Writing a precise prompt forces you to actually think through the task before coding it, which is not a bad habit regardless of tooling. The context isolation means no agent accumulates state or makes cross-task assumptions. You give up the convenience of "the AI remembers what we discussed" and gain reproducibility.
+
+If a task requires subtle judgment about cross-cutting concerns — security, data modeling, novel algorithms — I write that code myself. AI is a force multiplier on execution, not a replacement for design.

--- a/_posts/2026-04-01-datascrapexter-architecture.md
+++ b/_posts/2026-04-01-datascrapexter-architecture.md
@@ -1,0 +1,90 @@
+---
+layout: post
+title: "DataScrapexter: Architecture of a Production Go Scraping Framework"
+date: 2026-04-01
+permalink: /blog/2026/04/01/datascrapexter-architecture/
+category: deep-dive
+tags: [go, scraping, architecture, colly]
+lang: en
+description: "A walkthrough of DataScrapexter's layered Go architecture — from request management to anti-detection to multi-format output."
+excerpt: "Most scraping tools are either a thin wrapper around an HTTP client or a full browser automation harness. DataScrapexter sits between those extremes deliberately, and the architecture reflects that choice."
+---
+
+Most scraping tools are either a thin wrapper around an HTTP client or a full browser automation harness. DataScrapexter sits between those extremes deliberately, and the architecture reflects that choice.
+
+## The Four-Tier Service Model
+
+DataScrapexter is offered as a tiered service, and the tiers are not just pricing — they correspond to meaningfully different technical configurations:
+
+- **Basic**: Static HTML sites. Colly handles fetch and parse; no browser involved.
+- **Standard**: Sites with light JavaScript rendering. Colly fetches; a small post-processing step handles common SPA patterns like `<script type="application/json">` data islands.
+- **Professional**: Full JS rendering required. `chromedp` drives a headless Chromium instance; Colly is not involved in the fetch path.
+- **Enterprise**: Anti-bot bypass, residential proxy rotation, CAPTCHA solving, custom extraction logic. The pipeline is the Professional tier plus a detection-bypass middleware layer.
+
+This tiering is reflected in the codebase as a factory pattern: a `FetcherFactory` takes a config struct and returns a `Fetcher` interface. The caller never instantiates Colly or chromedp directly.
+
+## The Pipeline
+
+Every request flows through five stages regardless of tier:
+
+```
+Fetcher → Detector Bypass → Extractor → Normalizer → Formatter
+```
+
+**Fetcher** handles the HTTP lifecycle — connection pooling, retry logic, rate limiting, and cookie jar management. For Colly-backed tiers, this wraps `colly.Collector` with additional middleware. For chromedp tiers, it wraps a `chromedp.Context` with page lifecycle hooks (wait for network idle, scroll to trigger lazy loads, etc.).
+
+**Detector Bypass** is a no-op in Basic/Standard tiers. In Professional and Enterprise it injects realistic browser fingerprints: User-Agent rotation, `Accept-Language`, TLS fingerprint normalization, and timing jitter between requests. The middleware is a chain of `func(req *Request) error` steps, so individual bypass techniques can be swapped or composed without touching surrounding code.
+
+**Extractor** takes the raw HTML (or DOM snapshot from chromedp) and applies CSS selectors or XPath expressions defined in a scraping config file (YAML or JSON). The config schema is the same across all tiers. An extractor produces a `map[string]interface{}` per scraped entity.
+
+**Normalizer** applies type coercion, cleaning rules (trim whitespace, strip HTML tags, parse prices/dates), and field renaming. The normalization rules live in the same config file as the selectors, under a `transforms` key.
+
+**Formatter** serializes to the requested output: JSON, CSV, or XLSX. Each format has its own `Formatter` implementation behind a `format.Formatter` interface. Adding a new output format is a single struct implementing two methods.
+
+## Concurrency Model
+
+DataScrapexter uses a worker pool pattern with configurable parallelism:
+
+```go
+pool := scraper.NewWorkerPool(cfg.Workers, fetcher, extractor)
+pool.Submit(urls)
+results := pool.Drain()
+```
+
+`Workers` defaults to 5 for Basic, 3 for Professional (chromedp instances are heavier), and is user-configurable up to tier limits. The pool manages a `semaphore` channel to cap goroutines and a `results` channel that the formatter drains. Errors are collected separately and reported after all URLs are processed.
+
+## Why Colly and chromedp Coexist
+
+The obvious question is why not use chromedp for everything. Two reasons:
+
+1. **Performance.** A Colly-based fetch completes in ~50ms per page. A chromedp fetch, including browser launch amortization, is closer to 500ms with a warm pool. For a job scraping 10,000 product pages, that difference is roughly 11 hours.
+
+2. **Detectability.** Headless browsers have well-known fingerprints. Running chromedp against a site that does not need JS rendering increases detection risk without benefit.
+
+The factory pattern means the calling code is identical regardless of which fetcher is active. Switching a site from Colly to chromedp is a one-line config change.
+
+## Config-Driven Design
+
+The entire extraction logic is in YAML, not code. A client can change selectors, add fields, or adjust normalization rules without a deployment. This was a deliberate design decision: the framework is a runtime that interprets scraping specs, not a collection of site-specific scrapers baked into the binary.
+
+```yaml
+site: example-shop
+base_url: https://example.com/products
+pagination:
+  selector: "a.next-page"
+  max_pages: 50
+fields:
+  - name: title
+    selector: "h1.product-title"
+  - name: price
+    selector: "span.price"
+    transform: parse_price
+  - name: sku
+    selector: "[data-sku]"
+    attribute: data-sku
+output:
+  format: csv
+  path: ./output/products.csv
+```
+
+This approach keeps the core framework stable while client-specific logic stays in version-controlled config files rather than forked code.

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -472,3 +472,49 @@
     color: var(--brand-yellow);
   }
 }
+
+/* ── Post card ── */
+.post-card {
+  border-bottom: 1px solid var(--brand-border, #e5e5e5);
+  padding-block: var(--sp-6);
+  &:last-child { border-bottom: none; }
+}
+.post-card__meta {
+  display: flex; align-items: center; gap: var(--sp-3);
+  font-size: var(--text-sm); color: var(--brand-muted);
+  margin-bottom: var(--sp-3);
+}
+.post-card__title {
+  font-size: var(--text-xl); margin: 0 0 var(--sp-3) 0;
+  a { color: var(--brand-black); text-decoration: none; }
+  a:hover { color: var(--brand-green); }
+}
+.post-card__excerpt { color: var(--brand-muted); margin: 0 0 var(--sp-3) 0; }
+
+/* ── Category pill ── */
+.category-pill {
+  display: inline-block; padding: 2px 10px;
+  border-radius: var(--r-full); font-size: var(--text-xs);
+  font-weight: 500; background: var(--brand-surface);
+  color: var(--brand-green); border: 1px solid var(--brand-green);
+  text-decoration: none;
+  &:hover { background: var(--brand-green); color: white; }
+}
+
+/* ── Reading time ── */
+.reading-time { font-size: var(--text-xs); color: var(--brand-muted); }
+
+/* ── Category filter row ── */
+.category-filter {
+  display: flex; flex-wrap: wrap; gap: var(--sp-2);
+  margin-bottom: var(--sp-7);
+  a {
+    padding: 4px 14px; border-radius: var(--r-full);
+    font-size: var(--text-sm); text-decoration: none;
+    border: 1px solid var(--brand-border, #e5e5e5);
+    color: var(--brand-muted);
+    &:hover, &.active {
+      background: var(--brand-green); color: white; border-color: var(--brand-green);
+    }
+  }
+}

--- a/_sass/_pages.scss
+++ b/_sass/_pages.scss
@@ -110,3 +110,32 @@
   color: var(--brand-muted);
   margin-bottom: var(--sp-7);
 }
+
+/* ── Post page ── */
+.post-header {
+  padding-block: var(--sp-6) var(--sp-4);
+  border-bottom: 1px solid var(--brand-border, #e5e5e5);
+  margin-bottom: var(--sp-6);
+}
+.post-meta {
+  display: flex; align-items: center; flex-wrap: wrap;
+  gap: var(--sp-3); font-size: var(--text-sm); color: var(--brand-muted);
+  margin-top: var(--sp-3);
+}
+.post-body {
+  max-width: var(--max-prose); margin-inline: 0;
+  line-height: 1.75;
+  h2 { font-size: var(--text-2xl); margin-block: var(--sp-6) var(--sp-3); }
+  h3 { font-size: var(--text-xl); margin-block: var(--sp-5) var(--sp-2); }
+  p { margin-bottom: var(--sp-4); }
+  code { background: var(--brand-surface); padding: 2px 6px; border-radius: var(--r-sm); font-size: 0.9em; }
+  pre { background: var(--brand-surface); padding: var(--sp-4); border-radius: var(--r-md); overflow-x: auto; margin-bottom: var(--sp-4); }
+  blockquote { border-left: 3px solid var(--brand-green); padding-left: var(--sp-4); color: var(--brand-muted); margin: var(--sp-4) 0; }
+}
+.post-nav {
+  display: flex; justify-content: space-between; gap: var(--sp-4);
+  padding-block: var(--sp-6); border-top: 1px solid var(--brand-border, #e5e5e5);
+  font-size: var(--text-sm);
+  a { color: var(--brand-green); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+}

--- a/blog/categories/ai-practice.md
+++ b/blog/categories/ai-practice.md
@@ -1,0 +1,6 @@
+---
+layout: blog-category
+title: "AI Practice"
+permalink: /blog/categories/ai-practice/
+category: ai-practice
+---

--- a/blog/categories/case-study.md
+++ b/blog/categories/case-study.md
@@ -1,0 +1,6 @@
+---
+layout: blog-category
+title: "Case Studies"
+permalink: /blog/categories/case-study/
+category: case-study
+---

--- a/blog/categories/deep-dive.md
+++ b/blog/categories/deep-dive.md
@@ -1,0 +1,6 @@
+---
+layout: blog-category
+title: "Technical Deep-Dives"
+permalink: /blog/categories/deep-dive/
+category: deep-dive
+---

--- a/blog/categories/methodology.md
+++ b/blog/categories/methodology.md
@@ -1,0 +1,6 @@
+---
+layout: blog-category
+title: "Methodology"
+permalink: /blog/categories/methodology/
+category: methodology
+---

--- a/blog/categories/release-notes.md
+++ b/blog/categories/release-notes.md
@@ -1,0 +1,6 @@
+---
+layout: blog-category
+title: "Release Notes"
+permalink: /blog/categories/release-notes/
+category: release-notes
+---

--- a/blog/categories/thoughts.md
+++ b/blog/categories/thoughts.md
@@ -1,0 +1,6 @@
+---
+layout: blog-category
+title: "Thoughts"
+permalink: /blog/categories/thoughts/
+category: thoughts
+---

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,0 +1,6 @@
+---
+layout: blog-index
+title: Blog
+permalink: /blog/
+description: "Thoughts on Go, data extraction, AI tooling, and freelance engineering."
+---

--- a/blog/tags.md
+++ b/blog/tags.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: Tags
+permalink: /blog/tags/
+description: "All blog post tags"
+---
+
+<div class="tag-cloud" style="display:flex;flex-wrap:wrap;gap:var(--sp-2);margin-top:var(--sp-4);">
+{% assign sorted_tags = site.tags | sort %}
+{% for tag in sorted_tags %}
+  {% assign tag_name = tag | first %}
+  {% assign tag_posts = tag | last %}
+  <a href="#{{ tag_name | slugify }}" class="tag" style="font-size:{{ tag_posts.size | times: 2 | plus: 12 }}px;">
+    {{ tag_name }} ({{ tag_posts.size }})
+  </a>
+{% endfor %}
+</div>
+
+{% assign sorted_tags = site.tags | sort %}
+{% for tag in sorted_tags %}
+  {% assign tag_name = tag | first %}
+  {% assign tag_posts = tag | last %}
+  <h2 id="{{ tag_name | slugify }}" style="margin-top:var(--sp-7);">{{ tag_name }}</h2>
+  <ul>
+    {% for post in tag_posts %}
+    <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a> — <time>{{ post.date | date: "%B %-d, %Y" }}</time></li>
+    {% endfor %}
+  </ul>
+{% endfor %}

--- a/blog/tags.md
+++ b/blog/tags.md
@@ -16,7 +16,6 @@ description: "All blog post tags"
 {% endfor %}
 </div>
 
-{% assign sorted_tags = site.tags | sort %}
 {% for tag in sorted_tags %}
   {% assign tag_name = tag | first %}
   {% assign tag_posts = tag | last %}


### PR DESCRIPTION
## Summary

- **Blog data & layouts** — `_data/blog-categories.yml` (6 categories), `_layouts/post.html` (breadcrumb, bilingual meta, reading time, prev/next nav), `_layouts/blog-index.html`, `_layouts/blog-category.html`
- **Post card** — `_includes/post-card.html` with date, category pill, reading time, excerpt, tags; fully bilingual via `site.active_lang`
- **Blog CSS** — `.post-card`, `.category-pill`, `.category-filter`, `.post-body`, `.post-nav` added to `_sass/`
- **Pages** — `/blog/`, `/blog/categories/<slug>/` (×6), `/blog/tags/`
- **Home "Latest Writing"** — section showing 3 most recent posts, conditionally rendered, bilingual
- **5 first articles:**
  - [AI Practice] Claude Code in Freelance: How I Ship Faster Without Cutting Corners
  - [Deep Dive] DataScrapexter: Architecture of a Production Go Scraping Framework
  - [Case Study] Automating KeepinCRM: From Manual Order Tracking to Zero-Touch Fulfillment
  - [Methodology] Vibe Coding Without Vibes: Keeping Engineering Standards While Using AI
  - [Thoughts] Jekyll + Polyglot on GitHub Pages: What Actually Works in 2026

## Test Plan

- [ ] `/blog/` — shows 5 posts with category pills and reading times
- [ ] `/blog/categories/ai-practice/` — shows only the Claude Code article
- [ ] `/blog/tags/` — tag cloud with all tags from the 5 posts
- [ ] `/` home — "Latest Writing" section shows 3 most recent posts
- [ ] `/blog/2026/04/01/claude-code-freelance-workflow/` — full post with prev/next nav
- [ ] `UA` button in header on any post page links to `/uk/...` (polyglot handles it)
- [ ] `/feed.xml` — 5 Atom `<entry>` elements present

🤖 Generated with [Claude Code](https://claude.com/claude-code)