### PR TITLE
Fix deploy: switch to official GH Pages Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,8 +30,18 @@ jobs:
         env:
           JEKYLL_ENV: production
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
+          path: ./_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Replace `peaceiris/actions-gh-pages` with official `actions/upload-pages-artifact` + `actions/deploy-pages`
- Update permissions: `pages: write`, `id-token: write` (required by `actions/deploy-pages`)
- Add concurrency group to prevent overlapping deploys

## Why
`build_type: workflow` on this repo means GitHub Pages ignores branch-based deploys (peaceiris pushes to `gh-pages` branch but Pages never serves it). The site was serving the last native build — without our custom CSS, polyglot, or blog.

## Test Plan
- [ ] Actions run completes: build → deploy jobs both green
- [ ] `https://valpere.github.io/assets/css/main.css` returns compiled CSS (not raw `@use` directives)
- [ ] Site renders with brand styles