### PR TITLE
Remove empty image placeholder from project cards

### DIFF
--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -9,10 +9,6 @@
 <article class="card">
   {% if p.hero_image and p.hero_image != "" %}
   <img src="{{ p.hero_image | relative_url }}" alt="{{ card_title }}" class="card__image" loading="lazy" width="384" height="216">
-  {% else %}
-  <div class="card__image" style="background:var(--brand-surface);min-height:160px;display:flex;align-items:center;justify-content:center;">
-    <span style="color:var(--brand-muted);font-size:var(--text-sm);">{{ card_title }}</span>
-  </div>
   {% endif %}
   <div class="card__body">
     <h3 class="card__title" style="font-size:var(--text-lg);">


### PR DESCRIPTION
## Summary
Projects without `hero_image` (CLI Google Translator, TestWigr, TryTraGo) showed a grey empty box on the cards. Removed the fallback `<div>` — cards without images now just show the text body directly.

## Not changed
- Portfolio cards already had no fallback (correct)
- Post cards have no image slots (correct)