### PR TITLE
Add images to datascrapexter blog post

### DIFF
--- a/_posts/2026-03-01-vibe-coding-methodology.md
+++ b/_posts/2026-03-01-vibe-coding-methodology.md
@@ -8,7 +8,10 @@ tags: [ai, methodology, vibe-coding, claude, cursor]
 lang: en
 description: "Why AI-assisted development needs the same engineering discipline as hand-written code — and the practices that keep it maintainable."
 excerpt: "Vibe coding — the practice of describing what you want and letting an AI generate the implementation — is real and productive. It is also a reliable way to accumulate technical debt at AI speed if you treat the AI as a replacement for engineering discipline rather than an accelerant."
+image: /projects/assets/images/vibe_coding/vibe_coding-1-0768x0512.png
 ---
+
+![Vibe coding with AI tools](/projects/assets/images/vibe_coding/vibe_coding-1-0768x0512.png)
 
 Vibe coding — the practice of describing what you want and letting an AI generate the implementation — is real and productive. It is also a reliable way to accumulate technical debt at AI speed if you treat the AI as a replacement for engineering discipline rather than an accelerant.
 

--- a/_posts/2026-03-15-keepincrm-automation.md
+++ b/_posts/2026-03-15-keepincrm-automation.md
@@ -8,7 +8,10 @@ tags: [go, crm, automation, nova-poshta, telegram]
 lang: en
 description: "How a Go daemon watches Nova Poshta parcel statuses, moves CRM deals automatically, generates fiscal receipts, and sends SMS notifications."
 excerpt: "The client runs a small e-commerce operation — handmade goods, 50 to 80 orders on a busy day. Every morning started the same way: open Nova Poshta, check each tracking number, open KeepinCRM, move each deal to the matching stage. Forty-five minutes, every day, on a task a machine should own."
+image: /projects/assets/images/keepincrm/keepincrm_en-1-0632x0424.png
 ---
+
+![KeepinCRM automation](/projects/assets/images/keepincrm/keepincrm_en-1-0632x0424.png)
 
 The client runs a small e-commerce operation — handmade goods, 50 to 80 orders on a busy day. Every morning started the same way: open Nova Poshta, check each tracking number, open KeepinCRM, move each deal to the matching stage. Forty-five minutes, every day, on a task a machine should own.
 

--- a/_posts/2026-04-01-claude-code-freelance-workflow.md
+++ b/_posts/2026-04-01-claude-code-freelance-workflow.md
@@ -8,7 +8,10 @@ tags: [claude-code, ai, workflow, freelance]
 lang: en
 description: "How I integrated Claude Code's subagent-driven development into real freelance projects — concrete workflow, lessons, and tradeoffs."
 excerpt: "Six months ago I started using Claude Code as a primary development tool on client work. Not as an autocomplete or a rubber duck, but as a structured part of a repeatable workflow. Here is what that actually looks like in practice."
+image: /projects/assets/images/vibe_coding/ai+low-code_fusion-1-0768x0512.png
 ---
+
+![AI and low-code fusion in freelance workflow](/projects/assets/images/vibe_coding/ai+low-code_fusion-1-0768x0512.png)
 
 Six months ago I started using Claude Code as a primary development tool on client work. Not as an autocomplete or a rubber duck, but as a structured part of a repeatable workflow. Here is what that actually looks like in practice — with the warts included.
 

--- a/_posts/2026-04-01-datascrapexter-architecture.md
+++ b/_posts/2026-04-01-datascrapexter-architecture.md
@@ -8,7 +8,10 @@ tags: [go, scraping, architecture, colly]
 lang: en
 description: "A walkthrough of DataScrapexter's layered Go architecture — from request management to anti-detection to multi-format output."
 excerpt: "Most scraping tools are either a thin wrapper around an HTTP client or a full browser automation harness. DataScrapexter sits between those extremes deliberately, and the architecture reflects that choice."
+image: /projects/assets/images/data_scrapexter/professional_web_scraping_solution-1-0768x0512.png
 ---
+
+![DataScrapexter — professional web scraping solution](/projects/assets/images/data_scrapexter/professional_web_scraping_solution-1-0768x0512.png)
 
 Most scraping tools are either a thin wrapper around an HTTP client or a full browser automation harness. DataScrapexter sits between those extremes deliberately, and the architecture reflects that choice.
 
@@ -24,6 +27,8 @@ DataScrapexter is offered as a tiered service, and the tiers are not just pricin
 This tiering is reflected in the codebase as a factory pattern: a `FetcherFactory` takes a config struct and returns a `Fetcher` interface. The caller never instantiates Colly or chromedp directly.
 
 ## The Pipeline
+
+![Configuration workflow diagram](/projects/assets/images/data_scrapexter/configuration_workflow_diagram-1-0768x0512.png)
 
 Every request flows through five stages regardless of tier:
 
@@ -88,3 +93,5 @@ output:
 ```
 
 This approach keeps the core framework stable while client-specific logic stays in version-controlled config files rather than forked code.
+
+![Data output visualization](/projects/assets/images/data_scrapexter/data_output_visualization-1-0768x0512.png)


### PR DESCRIPTION
## Summary
Three images added from existing `projects/assets/images/data_scrapexter/` (768×512px):
- Hero banner at the top
- Configuration workflow diagram before the Pipeline section
- Data output visualization at the end