### PR TITLE
Add Blog to site navigation

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -10,3 +10,6 @@
 - label: "Projects"
   label_uk: "Проєкти"
   url: "/projects/"
+- label: "Blog"
+  label_uk: "Блог"
+  url: "/blog/"


### PR DESCRIPTION
## Summary
- Blog link was missing from the main navigation (EN and UK)
- Added Blog/Блог entry to `_data/nav.yml`

## Test Plan
- [x] Verified locally via Playwright: EN nav shows Home/About/Portfolio/Projects/Blog/UA
- [x] UK nav shows Головна/Про мене/Портфоліо/Проєкти/Блог/EN
- [x] Zero broken images across all pages
- [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)