### PR TITLE
Fix code block contrast in blog posts

### DIFF
--- a/_sass/_pages.scss
+++ b/_sass/_pages.scss
@@ -129,7 +129,8 @@
   h3 { font-size: var(--text-xl); margin-block: var(--sp-5) var(--sp-2); }
   p { margin-bottom: var(--sp-4); }
   code { background: var(--brand-surface); padding: 2px 6px; border-radius: var(--r-sm); font-size: 0.9em; }
-  pre { background: var(--brand-surface); padding: var(--sp-4); border-radius: var(--r-md); overflow-x: auto; margin-bottom: var(--sp-4); }
+  pre { background: var(--brand-black); color: var(--brand-white); padding: var(--sp-4); border-radius: var(--r-md); overflow-x: auto; margin-bottom: var(--sp-4); }
+  pre code { background: none; border: none; padding: 0; color: inherit; }
   blockquote { border-left: 3px solid var(--brand-green); padding-left: var(--sp-4); color: var(--brand-muted); margin: var(--sp-4) 0; }
 }
 .post-nav {


### PR DESCRIPTION
## Summary
- `.post-body pre` in `_pages.scss` was overriding `background` to `--brand-surface` (#f8f7f2, near-white) without setting a text color
- The base `pre` rule sets `color: --brand-white`, making code invisible (white on white)
- Fixed by setting `background: var(--brand-black)` and `color: var(--brand-white)` on `.post-body pre`, with `pre code` resetting to `background: none; color: inherit`

## Test Plan
- [x] Verified locally: code blocks now show white text on near-black background (rgb(255,255,255) on rgb(10,10,10))
- [x] Checked on `/blog/2026/04/17/chorus-cross-agent-plugin-mesh/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)