### PR TITLE
Add GitHub Copilot custom instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
 # Copilot Instructions — valpere.github.io
 
-Jekyll 4.4.1 portfolio site with jekyll-polyglot bilingual support (EN/UK). Minima 2.5 theme with full custom SCSS override.
+Jekyll 4.4.1 portfolio site with jekyll-polyglot bilingual support (English + Ukrainian). Minima 2.5 theme with full custom SCSS override.
 
 ## Architecture
 
-- `_posts/` — blog posts; every EN post (`lang: en`) must have a UK variant (`lang: uk`) with the same `permalink`
+- `_posts/` — blog posts; when a post is published in both languages, the EN (`lang: en`) and Ukrainian (`lang: uk`) versions must share the same `permalink`
 - `_data/projects.yml`, `_data/portfolio.yml` — data-driven cards; layouts iterate these files
 - `_sass/` — custom SCSS; `_tokens.scss` defines all CSS variables; never use hardcoded color values
 - `_layouts/`, `_includes/` — custom layouts and partials; Minima is a fallback only
@@ -19,16 +19,16 @@ layout: post
 title: "..."
 date: YYYY-MM-DD
 permalink: /blog/YYYY/MM/DD/slug/
-category: <one of: methodology, ai-practice, deep-dive, case-study, release-notes, thoughts>
+category: "<one of: methodology, ai-practice, deep-dive, case-study, release-notes, thoughts>"
 tags: [tag1, tag2]
-lang: en   # or uk
+lang: "<one of: en, uk>"
 description: "..."
 excerpt: "..."
 image: /path/to/hero.png
 ```
 - `image:` front matter must match the first inline image in the post body
-- First line after front matter must be `![alt text](same path as image: field)`
-- UK variant must have identical `permalink` to EN variant
+- First non-empty content line after front matter must be `![alt text](same path as image: field)`
+- When a Ukrainian (`lang: uk`) translation exists, it must have the same `permalink` as the EN version
 
 ### Project/portfolio pages
 - `layout: project` or `layout: portfolio-item`
@@ -36,16 +36,16 @@ image: /path/to/hero.png
 
 ## SCSS Rules (`_sass/*.scss`)
 
-- Use CSS variables from `_tokens.scss`, never raw hex values
-- Key tokens: `--brand-green: #168A53`, `--brand-yellow: #FED74F`, `--brand-black: #0a0a0a`, `--brand-white: #ffffff`, `--brand-surface: #f8f7f2`
+- Use CSS variables from `_tokens.scss`, never raw hex values; see `_sass/_tokens.scss` for canonical values
+- Key tokens include `--brand-green`, `--brand-yellow`, `--brand-black`, `--brand-white`, `--brand-surface`
 - `pre` blocks: must have `background: var(--brand-black)` and `color: var(--brand-white)` — light background on `pre` causes invisible code
 - `pre code` inside must reset: `background: none; border: none; padding: 0; color: inherit`
 
 ## Bilingual Rules
 
-- EN page and UK page share identical `permalink` — polyglot serves UK at `/uk/` prefix automatically
-- Navigation labels come from `_data/nav.yml` — both `label` (EN) and `label_uk` (UK) must be present
-- No bilingual content mixing in a single file (no EN + UA blocks in the same `.md`)
+- EN page and Ukrainian (`lang: uk`) page share identical `permalink` — polyglot serves Ukrainian at `/uk/` prefix automatically
+- Navigation labels come from `_data/nav.yml` — both `label` (EN) and `label_uk` (Ukrainian) must be present
+- No bilingual content mixing in a single file (no EN + Ukrainian blocks in the same `.md`)
 
 ## General
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Copilot Instructions — valpere.github.io
+
+Jekyll 4.4.1 portfolio site with jekyll-polyglot bilingual support (EN/UK). Minima 2.5 theme with full custom SCSS override.
+
+## Architecture
+
+- `_posts/` — blog posts; every EN post (`lang: en`) must have a UK variant (`lang: uk`) with the same `permalink`
+- `_data/projects.yml`, `_data/portfolio.yml` — data-driven cards; layouts iterate these files
+- `_sass/` — custom SCSS; `_tokens.scss` defines all CSS variables; never use hardcoded color values
+- `_layouts/`, `_includes/` — custom layouts and partials; Minima is a fallback only
+- `assets/images/posts/<slug>/` — blog post images; `projects/assets/images/<project>/` — project images
+
+## Front Matter Rules
+
+### Blog posts (`_posts/*.md`)
+Required fields — flag if any are missing:
+```yaml
+layout: post
+title: "..."
+date: YYYY-MM-DD
+permalink: /blog/YYYY/MM/DD/slug/
+category: <one of: methodology, ai-practice, deep-dive, case-study, release-notes, thoughts>
+tags: [tag1, tag2]
+lang: en   # or uk
+description: "..."
+excerpt: "..."
+image: /path/to/hero.png
+```
+- `image:` front matter must match the first inline image in the post body
+- First line after front matter must be `![alt text](same path as image: field)`
+- UK variant must have identical `permalink` to EN variant
+
+### Project/portfolio pages
+- `layout: project` or `layout: portfolio-item`
+- Must have `permalink`, `title`, `hero_image`, `tech` array
+
+## SCSS Rules (`_sass/*.scss`)
+
+- Use CSS variables from `_tokens.scss`, never raw hex values
+- Key tokens: `--brand-green: #168A53`, `--brand-yellow: #FED74F`, `--brand-black: #0a0a0a`, `--brand-white: #ffffff`, `--brand-surface: #f8f7f2`
+- `pre` blocks: must have `background: var(--brand-black)` and `color: var(--brand-white)` — light background on `pre` causes invisible code
+- `pre code` inside must reset: `background: none; border: none; padding: 0; color: inherit`
+
+## Bilingual Rules
+
+- EN page and UK page share identical `permalink` — polyglot serves UK at `/uk/` prefix automatically
+- Navigation labels come from `_data/nav.yml` — both `label` (EN) and `label_uk` (UK) must be present
+- No bilingual content mixing in a single file (no EN + UA blocks in the same `.md`)
+
+## General
+
+- No hardcoded strings that duplicate `_data/` content — use data files
+- Images: always include `loading="lazy"`, `width`, `height` attributes on `<img>` tags in HTML
+- `_site/`, `.jekyll-cache/`, `.sass-cache/`, `.worktrees/` are build artifacts — never commit
+- `CLAUDE.md` is excluded from the Jekyll build (`exclude:` in `_config.yml`) — do not add content there intended for the site

--- a/.github/instructions/posts.instructions.md
+++ b/.github/instructions/posts.instructions.md
@@ -11,9 +11,9 @@ layout: post
 title: "..."
 date: YYYY-MM-DD
 permalink: /blog/YYYY/MM/DD/slug/
-category: methodology | ai-practice | deep-dive | case-study | release-notes | thoughts
+category: "<one of: methodology, ai-practice, deep-dive, case-study, release-notes, thoughts>"
 tags: [...]
-lang: en   # or: uk
+lang: "<one of: en, uk>"
 description: "One sentence, under 160 chars"
 excerpt: "First paragraph of the post"
 image: /path/to/hero-image.png
@@ -21,9 +21,9 @@ image: /path/to/hero-image.png
 
 ## Post body rules
 
-- First content line must be `![descriptive alt](same path as image: field)` — hero image inline
-- EN post (`lang: en`) must have a UK sibling (`lang: uk`) with identical `permalink`
-- UK file name: same slug + `-uk` suffix, e.g. `2026-04-17-my-post-uk.md`
+- First non-empty content line must be `![descriptive alt](same path as image: field)` — hero image inline
+- If a post is published in both English and Ukrainian, the EN (`lang: en`) and Ukrainian (`lang: uk`) versions should use the same `permalink`
+- When a Ukrainian translation exists, its file name should use the same slug with a `-uk` suffix, e.g. `2026-04-17-my-post-uk.md`
 - Code blocks: fenced with triple backticks + language tag, never indented
 - No mixing of English and Ukrainian content in the same file
 

--- a/.github/instructions/posts.instructions.md
+++ b/.github/instructions/posts.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "_posts/**/*.md"
+---
+
+# Blog Post Conventions
+
+## Required front matter (all fields mandatory)
+
+```yaml
+layout: post
+title: "..."
+date: YYYY-MM-DD
+permalink: /blog/YYYY/MM/DD/slug/
+category: methodology | ai-practice | deep-dive | case-study | release-notes | thoughts
+tags: [...]
+lang: en   # or: uk
+description: "One sentence, under 160 chars"
+excerpt: "First paragraph of the post"
+image: /path/to/hero-image.png
+```
+
+## Post body rules
+
+- First content line must be `![descriptive alt](same path as image: field)` — hero image inline
+- EN post (`lang: en`) must have a UK sibling (`lang: uk`) with identical `permalink`
+- UK file name: same slug + `-uk` suffix, e.g. `2026-04-17-my-post-uk.md`
+- Code blocks: fenced with triple backticks + language tag, never indented
+- No mixing of English and Ukrainian content in the same file
+
+## Image paths
+
+- Blog post images: `/assets/images/posts/<slug>/filename.png`
+- Reusing project images is allowed: `/projects/assets/images/<project>/filename.png`
+- `image:` field and the first `![...](...)` must reference the same path

--- a/.github/instructions/scss.instructions.md
+++ b/.github/instructions/scss.instructions.md
@@ -1,0 +1,53 @@
+---
+applyTo: "_sass/**/*.scss"
+---
+
+# SCSS Conventions
+
+## Token usage
+
+All colors, spacing, typography, and radii come from CSS variables in `_sass/_tokens.scss`. Never use raw hex values or hardcoded pixel values that duplicate a token.
+
+Key tokens:
+- Colors: `--brand-green`, `--brand-yellow`, `--brand-black`, `--brand-white`, `--brand-surface`, `--brand-muted`, `--brand-border`
+- Spacing: `--sp-1` through `--sp-8`
+- Text sizes: `--text-sm`, `--text-base`, `--text-lg`, `--text-xl`, `--text-2xl`, `--text-3xl`
+- Radii: `--r-sm`, `--r-md`, `--r-lg`
+- Font: `--font-sans`, `--font-mono`
+
+## Code block rules (critical)
+
+`pre` must always pair background and color together:
+
+```scss
+// Correct
+pre {
+  background: var(--brand-black);
+  color: var(--brand-white);
+}
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+}
+
+// Wrong — causes invisible text
+pre {
+  background: var(--brand-surface); // light bg + inherited white text = invisible
+}
+```
+
+## Specificity
+
+- More specific selectors (`.post-body pre`) override base selectors (`pre`)
+- When overriding `background` on a `pre`, always also set `color` explicitly
+- When overriding `background` on `pre code`, reset to `background: none; color: inherit`
+
+## Structure
+
+Files: `_tokens.scss`, `_base.scss`, `_layout.scss`, `_components.scss`, `_pages.scss`
+- `_tokens.scss` — variables only, no rules
+- `_base.scss` — element-level defaults
+- `_components.scss` — reusable UI components (`.btn`, `.card`, `.tag`)
+- `_pages.scss` — page-specific overrides


### PR DESCRIPTION
## Summary
- Adds `.github/copilot-instructions.md` (repo-wide, 2634 chars — under the 4000 char limit Copilot reads)
- Adds `.github/instructions/posts.instructions.md` (applies to `_posts/**/*.md`)
- Adds `.github/instructions/scss.instructions.md` (applies to `_sass/**/*.scss`)

Key rules covered:
- Required front matter fields for blog posts
- `image:` field must match first inline image in post body
- EN/UK post pairing requirements
- SCSS: always use tokens, never raw hex
- Code block contrast rule: `pre` with light background must also set light text color

## Test Plan
- [ ] Copilot code review picks up instructions on next PR touching `_posts/` or `_sass/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)