### PR TITLE
Fix duplicate image on chorus project page

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -4,7 +4,7 @@
   summary_en: "Open-source cross-agent plugin mesh connecting Claude Code, OpenCode, Gemini CLI, and Codex into a 4×3 delegation network. One install gives any agent the ability to delegate tasks to the other three — parallel reviews, council mode, root-cause debugging."
   summary_uk: "Open-source крос-агентна mesh, що з'єднує Claude Code, OpenCode, Gemini CLI та Codex у мережу делегування 4×3. Один плагін дозволяє будь-якому агенту делегувати задачі трьом іншим — паралельні review, council-режим, дебагінг."
   permalink: "/projects/chorus/"
-  hero_image: "/projects/assets/images/chorus/infographic-0384x0256.png"
+  hero_image: "/projects/assets/images/chorus/infographic-0900x0530.png"
   featured: true
   tech: ["Claude Code", "OpenCode", "Gemini CLI", "Codex", "MCP", "Plugin"]
   links:

--- a/projects/chorus-ua.md
+++ b/projects/chorus-ua.md
@@ -5,8 +5,6 @@ permalink: /projects/chorus/
 lang: uk
 ---
 
-![chorus — крос-агентна plugin mesh](/projects/assets/images/chorus/infographic-0900x0530.png)
-
 Більшість AI coding tools зроблені як острови.
 
 Ви обираєте один — Claude Code, OpenCode, Gemini CLI або Codex — і залишаєтеся в його workflow. Хочете другу думку? Треба скопіювати контекст, перейти в інший термінал, заново пояснити задачу, зачекати, порівняти відповіді й вручну перенести корисне назад.

--- a/projects/chorus.md
+++ b/projects/chorus.md
@@ -5,8 +5,6 @@ permalink: /projects/chorus/
 lang: en
 ---
 
-![chorus — cross-agent plugin mesh](/projects/assets/images/chorus/infographic-0900x0530.png)
-
 Most AI coding tools are designed like islands.
 
 You pick one — Claude Code, OpenCode, Gemini CLI, or Codex — and stay inside its workflow. A second opinion means copying context, switching terminals, re-explaining the task, waiting, comparing answers, and manually carrying the result back.


### PR DESCRIPTION
## Summary
- `_layouts/project.html` renders `hero_image` from `_data/projects.yml` in the page header
- The markdown body also started with `![...]` — causing the image to appear twice
- Removed inline image from `projects/chorus.md` and `projects/chorus-ua.md`
- Updated `hero_image` in `_data/projects.yml` from 384×256 to 900×530 for better quality

## Test Plan
- [x] Jekyll build succeeds
- [x] Image appears once at top of page, rendered by layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)