### PR TITLE
Update chorus: 4-agent → 6-agent mesh (add Cursor + Kilo)

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,12 +1,12 @@
 - slug: "chorus"
   title: "chorus"
   title_uk: "chorus"
-  summary_en: "Open-source cross-agent plugin mesh connecting Claude Code, OpenCode, Gemini CLI, and Codex into a 4×3 delegation network. One install gives any agent the ability to delegate tasks to the other three — parallel reviews, council mode, root-cause debugging."
-  summary_uk: "Open-source крос-агентна mesh, що з'єднує Claude Code, OpenCode, Gemini CLI та Codex у мережу делегування 4×3. Один плагін дозволяє будь-якому агенту делегувати задачі трьом іншим — паралельні review, council-режим, дебагінг."
+  summary_en: "Open-source cross-agent plugin mesh connecting Claude Code, OpenCode, Gemini CLI, Codex, Cursor, and Kilo into a full 6×6 delegation network. One install gives any agent the ability to delegate tasks to the other five — parallel reviews, council mode, root-cause debugging."
+  summary_uk: "Open-source крос-агентна mesh, що з'єднує Claude Code, OpenCode, Gemini CLI, Codex, Cursor та Kilo у повну мережу делегування 6×6. Один плагін дозволяє будь-якому агенту делегувати задачі п'ятьом іншим — паралельні review, council-режим, дебагінг."
   permalink: "/projects/chorus/"
   hero_image: "/projects/assets/images/chorus/infographic-0900x0530.png"
   featured: true
-  tech: ["Claude Code", "OpenCode", "Gemini CLI", "Codex", "MCP", "Plugin"]
+  tech: ["Claude Code", "OpenCode", "Gemini CLI", "Codex", "Cursor", "Kilo", "MCP", "Plugin"]
   links:
     github: "https://github.com/valpere/chorus"
 

--- a/projects/chorus-ua.md
+++ b/projects/chorus-ua.md
@@ -15,7 +15,7 @@ lang: uk
 
 chorus — open-source колекція плагінів, яка створює **повну mesh делегування 6×6** між шістьма AI coding CLI:
 
-| Від \ До | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
+| Від \\ До | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
 |----------|:------:|:--------:|:------:|:-----:|:------:|:----:|
 | Claude Code | — | ✅ | ✅ | ✅ | ✅ | ✅ |
 | OpenCode | ✅ | — | ✅ | ✅ | ✅ | ✅ |

--- a/projects/chorus-ua.md
+++ b/projects/chorus-ua.md
@@ -7,22 +7,24 @@ lang: uk
 
 Більшість AI coding tools зроблені як острови.
 
-Ви обираєте один — Claude Code, OpenCode, Gemini CLI або Codex — і залишаєтеся в його workflow. Хочете другу думку? Треба скопіювати контекст, перейти в інший термінал, заново пояснити задачу, зачекати, порівняти відповіді й вручну перенести корисне назад.
+Ви обираєте один — Claude Code, OpenCode, Gemini CLI, Codex, Cursor або Kilo — і залишаєтеся в його workflow. Хочете другу думку? Треба скопіювати контекст, перейти в інший термінал, заново пояснити задачу, зачекати, порівняти відповіді й вручну перенести корисне назад.
 
 **chorus** прибирає цей крок.
 
 ## Що це таке
 
-chorus — open-source колекція плагінів, яка створює **mesh делегування 4×3** між чотирма AI coding CLI:
+chorus — open-source колекція плагінів, яка створює **повну mesh делегування 6×6** між шістьма AI coding CLI:
 
-| Від \ До | Claude | OpenCode | Gemini | Codex |
-|----------|--------|----------|--------|-------|
-| Claude Code | — | ✅ | ✅ | ✅ |
-| OpenCode | ✅ | — | ✅ | ✅ |
-| Gemini CLI | ✅ | ✅ | — | ✅ |
-| Codex | ✅ | ✅ | ✅ | — |
+| Від \ До | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
+|----------|:------:|:--------:|:------:|:-----:|:------:|:----:|
+| Claude Code | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+| OpenCode | ✅ | — | ✅ | ✅ | ✅ | ✅ |
+| Gemini CLI | ✅ | ✅ | — | ✅ | ✅ | ✅ |
+| Codex | ✅ | ✅ | ✅ | — | ✅ | ✅ |
+| Cursor | ✅ | ✅ | ✅ | ✅ | — | ✅ |
+| Kilo | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 
-Кожен агент може делегувати задачі трьом іншим, не виходячи зі свого інтерфейсу.
+Кожен агент може делегувати задачі п'ятьом іншим, не виходячи зі свого інтерфейсу.
 
 ## Інтеграція
 
@@ -31,6 +33,8 @@ chorus — open-source колекція плагінів, яка створює 
 /opencode:run refactor the auth module
 /gemini:review check this diff for edge cases
 /codex:run write tests for the new retry logic
+/cursor:run check if this fits existing codebase patterns
+/kilo:run review for naming clarity and maintainability
 ```
 
 **OpenCode** отримує MCP tools:
@@ -38,32 +42,38 @@ chorus — open-source колекція плагінів, яка створює 
 delegate_claude("review this migration for data loss risk")
 delegate_gemini("analyze this for performance bottlenecks")
 delegate_codex("add integration tests")
+delegate_cursor("check pattern consistency across the repo")
+delegate_kilo("review for long-term readability")
 ```
 
-**Gemini CLI** і **Codex** отримують skills — встановіть раз, потім просто скажіть агенту делегувати природною мовою.
+**Gemini CLI**, **Codex**, **Cursor** і **Kilo** отримують skills/rules — встановіть раз, потім просто делегуйте природною мовою.
 
 ## Паралельне code review
 
-Даєте трьом різним агентам один diff незалежно, кожен із різним фокусом:
+Даєте п'ятьом різним агентам один diff незалежно, кожен із різним фокусом:
 
 ```text
-/gemini:review — correctness та edge cases
-/codex:run    — test coverage
-/opencode:run — архітектура та спрощення
+/gemini:review   — correctness та edge cases
+/codex:run       — test coverage та пропущені кейси
+/cursor:run      — інтеграція з кодовою базою та узгодженість патернів
+/kilo:run        — підтримуваність та якість найменування
+/claude:review   — безпека та коректність
 ```
 
 У різних моделей різні слабкі місця. Один пропустить edge case, який інший спіймає. chorus надає матеріал, рішення залишається за вами.
+
+OpenCode бере участь у повній mesh 6×6, але виключений із паралельних workflow-патернів — його TUI stdout не можна перехопити програмно.
 
 ## Named workflow команди
 
 | Команда | Що робить |
 |---|---|
-| `/chorus:review` | Паралельне review `git diff HEAD` — одна команда, 3 незалежні думки |
-| `/chorus:council` | Одне завдання трьом агентам із різними ролями; host синтезує |
-| `/chorus:debug` | Ранжовані гіпотези першопричини від 3 агентів для симптому баґу |
+| `/chorus:review` | Паралельне review `git diff HEAD` — одна команда, 5 незалежних думок |
+| `/chorus:council` | Одне завдання п'ятьом агентам із різними ролями; host синтезує |
+| `/chorus:debug` | Ранжовані гіпотези першопричини від 5 агентів для симптому баґу |
 | `/chorus:second-opinion` | Швидка незалежна перевірка одним обраним агентом |
 
-OpenCode отримує їх як MCP tools: `council`, `parallel_review`, `parallel_debug`, `second_opinion`. Gemini CLI та Codex — як skills.
+OpenCode отримує їх як MCP tools: `council`, `parallel_review`, `parallel_debug`, `second_opinion`. Gemini CLI, Codex, Cursor та Kilo — як skills/rules.
 
 ## Встановлення
 
@@ -73,8 +83,13 @@ claude plugin install https://github.com/valpere/chorus
 
 # OpenCode
 opencode plugin @valpere/chorus-opencode
+
+# Gemini CLI
+gemini skills install https://github.com/valpere/chorus --path for-gemini/claude
+gemini skills install https://github.com/valpere/chorus --path for-gemini/opencode
+# ... та інші агенти
 ```
 
-Повне встановлення для Gemini CLI та Codex — у [README](https://github.com/valpere/chorus).
+Повне встановлення для Codex, Cursor та Kilo — у [README](https://github.com/valpere/chorus).
 
-chorus не намагається стати новою IDE або orchestration platform. Це plumbing між інструментами, якими розробники вже користуються. Одна інсталяція, чотири агенти, жодних нових workflow.
+chorus не намагається стати новою IDE або orchestration platform. Це plumbing між інструментами, якими розробники вже користуються. Одна інсталяція, шість агентів, жодних нових workflow.

--- a/projects/chorus.md
+++ b/projects/chorus.md
@@ -7,22 +7,24 @@ lang: en
 
 Most AI coding tools are designed like islands.
 
-You pick one — Claude Code, OpenCode, Gemini CLI, or Codex — and stay inside its workflow. A second opinion means copying context, switching terminals, re-explaining the task, waiting, comparing answers, and manually carrying the result back.
+You pick one — Claude Code, OpenCode, Gemini CLI, Codex, Cursor, or Kilo — and stay inside its workflow. A second opinion means copying context, switching terminals, re-explaining the task, waiting, comparing answers, and manually carrying the result back.
 
 **chorus** removes that step.
 
 ## What It Does
 
-chorus is an open-source plugin collection that creates a **4×3 delegation mesh** between four AI coding CLIs:
+chorus is an open-source plugin collection that creates a **full 6×6 delegation mesh** between six AI coding CLIs:
 
-| From \ To   | Claude | OpenCode | Gemini | Codex |
-|-------------|--------|----------|--------|-------|
-| Claude Code |   —    |  ✅      |  ✅    |  ✅   |
-| OpenCode    |  ✅    |  —       |  ✅    |  ✅   |
-| Gemini CLI  |  ✅    |  ✅      |  —     |  ✅   |
-| Codex       |  ✅    |  ✅      |  ✅    |  —    |
+| From \ To   | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
+|-------------|:------:|:--------:|:------:|:-----:|:------:|:----:|
+| Claude Code |   —    |  ✅      |  ✅    |  ✅   |  ✅    |  ✅  |
+| OpenCode    |  ✅    |   —      |  ✅    |  ✅   |  ✅    |  ✅  |
+| Gemini CLI  |  ✅    |  ✅      |   —    |  ✅   |  ✅    |  ✅  |
+| Codex       |  ✅    |  ✅      |  ✅    |   —   |  ✅    |  ✅  |
+| Cursor      |  ✅    |  ✅      |  ✅    |  ✅   |   —    |  ✅  |
+| Kilo        |  ✅    |  ✅      |  ✅    |  ✅   |  ✅    |   —  |
 
-Each agent can delegate tasks to the other three, without leaving its own interface.
+Each agent can delegate tasks to the other five, without leaving its own interface.
 
 ## Integration
 
@@ -31,6 +33,8 @@ Each agent can delegate tasks to the other three, without leaving its own interf
 /opencode:run refactor the auth module
 /gemini:review check this diff for edge cases
 /codex:run write tests for the new retry logic
+/cursor:run check if this fits existing codebase patterns
+/kilo:run review for naming clarity and maintainability
 ```
 
 **OpenCode** gets MCP tools:
@@ -38,32 +42,38 @@ Each agent can delegate tasks to the other three, without leaving its own interf
 delegate_claude("review this migration for data loss risk")
 delegate_gemini("analyze this for performance bottlenecks")
 delegate_codex("add integration tests")
+delegate_cursor("check pattern consistency across the repo")
+delegate_kilo("review for long-term readability")
 ```
 
-**Gemini CLI** and **Codex** get skills — install once, then ask in natural language.
+**Gemini CLI**, **Codex**, **Cursor**, and **Kilo** get skills/rules — install once, then delegate in natural language.
 
 ## Parallel Code Review
 
-Ask three different agents to review the same diff independently, each with a different focus:
+Ask five different agents to review the same diff independently, each with a different focus:
 
 ```text
-/gemini:review — correctness and edge cases
-/codex:run    — test coverage
-/opencode:run — architecture and simplification
+/gemini:review   — correctness and edge cases
+/codex:run       — test coverage and missing cases
+/cursor:run      — codebase integration and pattern consistency
+/kilo:run        — maintainability and naming clarity
+/claude:review   — security and correctness
 ```
 
 Different models have genuinely different failure modes. One may miss an edge case another catches. chorus provides the raw material; judgment stays with you.
+
+OpenCode participates in the full 6×6 mesh but is excluded from parallel workflow patterns — its TUI stdout isn't capturable programmatically.
 
 ## Named Workflow Commands
 
 | Command | What it does |
 |---|---|
-| `/chorus:review` | Parallel review of `git diff HEAD` — one command, 3 independent opinions |
-| `/chorus:council` | Same task to all 3 agents with different roles; host synthesizes |
-| `/chorus:debug` | Ranked root-cause hypotheses from 3 agents for a bug symptom |
+| `/chorus:review` | Parallel review of `git diff HEAD` — one command, 5 independent opinions |
+| `/chorus:council` | Same task to all 5 agents with different roles; host synthesizes |
+| `/chorus:debug` | Ranked root-cause hypotheses from 5 agents for a bug symptom |
 | `/chorus:second-opinion` | Quick independent check from one chosen agent |
 
-OpenCode gets these as MCP tools: `council`, `parallel_review`, `parallel_debug`, `second_opinion`. Gemini CLI and Codex get them as skills.
+OpenCode gets these as MCP tools: `council`, `parallel_review`, `parallel_debug`, `second_opinion`. Gemini CLI, Codex, Cursor, and Kilo get them as skills/rules.
 
 ## Install
 
@@ -73,8 +83,13 @@ claude plugin install https://github.com/valpere/chorus
 
 # OpenCode
 opencode plugin @valpere/chorus-opencode
+
+# Gemini CLI
+gemini skills install https://github.com/valpere/chorus --path for-gemini/claude
+gemini skills install https://github.com/valpere/chorus --path for-gemini/opencode
+# ... and other agents
 ```
 
-Full installation for Gemini CLI and Codex is in the [README](https://github.com/valpere/chorus).
+Full installation for Codex, Cursor, and Kilo is in the [README](https://github.com/valpere/chorus).
 
-chorus is not trying to be a new IDE or orchestration platform. It is plumbing between tools developers already use. One install, four agents, zero new workflows forced on you.
+chorus is not trying to be a new IDE or orchestration platform. It is plumbing between tools developers already use. One install, six agents, zero new workflows forced on you.

--- a/projects/chorus.md
+++ b/projects/chorus.md
@@ -15,7 +15,7 @@ You pick one — Claude Code, OpenCode, Gemini CLI, Codex, Cursor, or Kilo — a
 
 chorus is an open-source plugin collection that creates a **full 6×6 delegation mesh** between six AI coding CLIs:
 
-| From \ To   | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
+| From \\ To  | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
 |-------------|:------:|:--------:|:------:|:-----:|:------:|:----:|
 | Claude Code |   —    |  ✅      |  ✅    |  ✅   |  ✅    |  ✅  |
 | OpenCode    |  ✅    |   —      |  ✅    |  ✅   |  ✅    |  ✅  |


### PR DESCRIPTION
## Summary

- Expand chorus project pages (EN + UA) from 4-agent 4×3 mesh to 6-agent 6×6 mesh
- Add **Cursor Agent CLI** and **Kilo Code CLI** to integration examples, mesh table, and workflow commands
- Update parallel review count: 3 agents → 5 agents (OpenCode excluded from parallel patterns)
- Update `_data/projects.yml` summary and tech tags to reflect the new agents

## Changes

- `projects/chorus.md` — rewritten with 6×6 mesh table, Cursor/Kilo slash commands, updated workflow commands
- `projects/chorus-ua.md` — same updates in Ukrainian
- `_data/projects.yml` — updated summaries and tech: array (added Cursor, Kilo)