### PR TITLE
Update chorus: 4-agent → 6-agent mesh (home hero + blog posts)

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,8 +40,8 @@ layout: default
     <span class="card-meta">{% if site.active_lang == 'uk' %}Зараз будується{% else %}Currently building{% endif %}</span>
     <h3>{{ fp.title }}</h3>
     <div class="card-stats">
-      <div><div class="stat-n">4</div><div class="stat-l">agents</div></div>
-      <div><div class="stat-n">12</div><div class="stat-l">routes</div></div>
+      <div><div class="stat-n">6</div><div class="stat-l">agents</div></div>
+      <div><div class="stat-n">30</div><div class="stat-l">routes</div></div>
       <div><div class="stat-n">1</div><div class="stat-l">install</div></div>
       <div><div class="stat-n">∞</div><div class="stat-l">workflows</div></div>
     </div>

--- a/_posts/2026-04-17-chorus-cross-agent-plugin-mesh-uk.md
+++ b/_posts/2026-04-17-chorus-cross-agent-plugin-mesh-uk.md
@@ -6,7 +6,8 @@ category: release-notes
 tags: [AI, chorus, claude-code, opencode, gemini, codex, cursor, kilo, open-source]
 lang: uk
 permalink: /blog/2026/04/17/chorus-cross-agent-plugin-mesh/
-description: "chorus — open-source колекція плагінів, яка створює повну mesh делегування 6×6 між Claude Code, OpenCode, Gemini CLI, Codex, Cursor та Kilo, не виходячи з поточного інтерфейсу."
+description: "chorus — open-source колекція плагінів для делегування між Claude Code, OpenCode, Gemini CLI, Codex, Cursor і Kilo."
+excerpt: "Більшість AI coding tools зроблені як острови."
 image: /assets/images/posts/chorus/infographic-900x530.png
 ---
 
@@ -36,7 +37,7 @@ chorus — open-source колекція плагінів, яка створює 
 ## Інтеграція
 
 **Claude Code** отримує slash commands:
-```
+```text
 /opencode:run refactor the auth module
 /gemini:review check this diff for edge cases
 /codex:run write tests for the new retry logic
@@ -45,7 +46,7 @@ chorus — open-source колекція плагінів, яка створює 
 ```
 
 **OpenCode** отримує MCP tools:
-```
+```text
 delegate_claude("review this migration for data loss risk")
 delegate_gemini("analyze this for performance bottlenecks")
 delegate_codex("add integration tests")

--- a/_posts/2026-04-17-chorus-cross-agent-plugin-mesh-uk.md
+++ b/_posts/2026-04-17-chorus-cross-agent-plugin-mesh-uk.md
@@ -3,10 +3,10 @@ layout: post
 title: "chorus: крос-агентна mesh для AI coding CLI"
 date: 2026-04-17
 category: release-notes
-tags: [AI, chorus, claude-code, opencode, gemini, codex, open-source]
+tags: [AI, chorus, claude-code, opencode, gemini, codex, cursor, kilo, open-source]
 lang: uk
 permalink: /blog/2026/04/17/chorus-cross-agent-plugin-mesh/
-description: "chorus — open-source колекція плагінів, яка створює mesh делегування 4×3 між Claude Code, OpenCode, Gemini CLI та Codex, не виходячи з поточного інтерфейсу."
+description: "chorus — open-source колекція плагінів, яка створює повну mesh делегування 6×6 між Claude Code, OpenCode, Gemini CLI, Codex, Cursor та Kilo, не виходячи з поточного інтерфейсу."
 image: /assets/images/posts/chorus/infographic-900x530.png
 ---
 
@@ -14,22 +14,24 @@ image: /assets/images/posts/chorus/infographic-900x530.png
 
 Більшість AI coding tools зроблені як острови.
 
-Ви обираєте один — Claude Code, OpenCode, Gemini CLI або Codex — і залишаєтеся в його workflow. Хочете другу думку? Треба скопіювати контекст, перейти в інший термінал, заново пояснити задачу, зачекати, порівняти відповіді й вручну перенести корисне назад.
+Ви обираєте один — Claude Code, OpenCode, Gemini CLI, Codex, Cursor або Kilo — і залишаєтеся в його workflow. Хочете другу думку? Треба скопіювати контекст, перейти в інший термінал, заново пояснити задачу, зачекати, порівняти відповіді й вручну перенести корисне назад.
 
 Я зробив **chorus**, щоб прибрати цей крок.
 
 ## Що це таке
 
-chorus — open-source колекція плагінів, яка створює **mesh делегування 4×3** між чотирма AI coding CLI:
+chorus — open-source колекція плагінів, яка створює **повну mesh делегування 6×6** між шістьма AI coding CLI:
 
-| Від \ До    | Claude | OpenCode | Gemini | Codex |
-|-------------|--------|----------|--------|-------|
-| Claude Code |   —    |  ✅      |  ✅    |  ✅   |
-| OpenCode    |  ✅    |  —       |  ✅    |  ✅   |
-| Gemini CLI  |  ✅    |  ✅      |  —     |  ✅   |
-| Codex       |  ✅    |  ✅      |  ✅    |  —    |
+| Від \\ До | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
+|-----------|:------:|:--------:|:------:|:-----:|:------:|:----:|
+| Claude Code | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+| OpenCode | ✅ | — | ✅ | ✅ | ✅ | ✅ |
+| Gemini CLI | ✅ | ✅ | — | ✅ | ✅ | ✅ |
+| Codex | ✅ | ✅ | ✅ | — | ✅ | ✅ |
+| Cursor | ✅ | ✅ | ✅ | ✅ | — | ✅ |
+| Kilo | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 
-Кожен агент може делегувати задачі трьом іншим, не виходячи зі свого інтерфейсу.
+Кожен агент може делегувати задачі п'ятьом іншим, не виходячи зі свого інтерфейсу.
 
 ## Інтеграція
 
@@ -38,6 +40,8 @@ chorus — open-source колекція плагінів, яка створює 
 /opencode:run refactor the auth module
 /gemini:review check this diff for edge cases
 /codex:run write tests for the new retry logic
+/cursor:run check if this fits existing codebase patterns
+/kilo:run review for naming clarity and maintainability
 ```
 
 **OpenCode** отримує MCP tools:
@@ -45,21 +49,40 @@ chorus — open-source колекція плагінів, яка створює 
 delegate_claude("review this migration for data loss risk")
 delegate_gemini("analyze this for performance bottlenecks")
 delegate_codex("add integration tests")
+delegate_cursor("check pattern consistency across the repo")
+delegate_kilo("review for long-term readability")
 ```
 
-**Gemini CLI** і **Codex** отримують skills — встановіть раз, потім просто скажіть агенту делегувати природною мовою.
+**Gemini CLI**, **Codex**, **Cursor** і **Kilo** отримують skills/rules — встановіть раз, потім просто делегуйте природною мовою.
 
 ## Workflow, який реально важливий
 
-Паралельне code review. Даєте трьом різним агентам один diff незалежно, кожен із різним фокусом:
+Паралельне code review. Даєте п'ятьом різним агентам один diff незалежно, кожен із різним фокусом:
 
 ```text
-/gemini:review — correctness та edge cases
-/codex:run    — test coverage
-/opencode:run — архітектура та спрощення
+/gemini:review   — correctness та edge cases
+/codex:run       — test coverage та пропущені кейси
+/cursor:run      — інтеграція з кодовою базою та узгодженість патернів
+/kilo:run        — підтримуваність та якість найменування
+/claude:review   — безпека та коректність
 ```
 
-У різних моделей різні слабкі місця. Один пропустить edge case, який інший спіймає. Один перебільшить архітектурні деталі, де інший помітить відсутній тест. Ви читаєте всі три відповіді й приймаєте рішення. Агенти надають матеріал, judgment залишається за вами.
+У різних моделей різні слабкі місця. Один пропустить edge case, який інший спіймає. Один перебільшить архітектурні деталі, де інший помітить відсутній тест. Ви читаєте всі п'ять відповідей і приймаєте рішення. Агенти надають матеріал, judgment залишається за вами.
+
+OpenCode бере участь у повній mesh 6×6, але виключений із паралельних workflow-патернів — його TUI stdout не можна перехопити програмно.
+
+## Named workflow команди
+
+Замість того, щоб щоразу вручну запускати п'ять окремих команд із різними промптами, chorus постачає named workflow patterns як перший клас installable plugins:
+
+| Команда | Що робить |
+|---|---|
+| `/chorus:review` | Паралельне review `git diff HEAD` — одна команда, 5 незалежних думок |
+| `/chorus:council` | Одне завдання п'ятьом агентам із різними ролями; host синтезує |
+| `/chorus:debug` | Ранжовані гіпотези першопричини від 5 агентів для симптому баґу |
+| `/chorus:second-opinion` | Швидка незалежна перевірка одним обраним агентом |
+
+OpenCode отримує їх як MCP tools: `council`, `parallel_review`, `parallel_debug`, `second_opinion`. Gemini CLI, Codex, Cursor та Kilo — як skills/rules.
 
 ## Встановлення
 
@@ -69,10 +92,14 @@ claude plugin install https://github.com/valpere/chorus
 
 # OpenCode
 opencode plugin @valpere/chorus-opencode
+
+# Gemini CLI
+gemini skills install https://github.com/valpere/chorus --path for-gemini/claude
+# ... та інші агенти
 ```
 
-Повне встановлення для Gemini CLI та Codex — у README.
+Повне встановлення для Codex, Cursor та Kilo — у [README](https://github.com/valpere/chorus).
 
-chorus не намагається стати новою IDE або orchestration platform. Це plumbing між інструментами, якими розробники вже користуються. Одна інсталяція, чотири агенти, жодних нових workflow.
+chorus не намагається стати новою IDE або orchestration platform. Це plumbing між інструментами, якими розробники вже користуються. Одна інсталяція, шість агентів, жодних нових workflow.
 
 **[https://github.com/valpere/chorus](https://github.com/valpere/chorus)**

--- a/_posts/2026-04-17-chorus-cross-agent-plugin-mesh.md
+++ b/_posts/2026-04-17-chorus-cross-agent-plugin-mesh.md
@@ -6,7 +6,8 @@ category: release-notes
 tags: [AI, chorus, claude-code, opencode, gemini, codex, cursor, kilo, open-source]
 lang: en
 permalink: /blog/2026/04/17/chorus-cross-agent-plugin-mesh/
-description: "chorus is an open-source plugin collection that creates a full 6×6 delegation mesh between Claude Code, OpenCode, Gemini CLI, Codex, Cursor, and Kilo — without leaving your current interface."
+description: "chorus creates a 6×6 mesh across Claude Code, OpenCode, Gemini CLI, Codex, Cursor, and Kilo."
+excerpt: "Most AI coding tools are designed like islands."
 image: /assets/images/posts/chorus/infographic-900x530.png
 ---
 
@@ -36,7 +37,7 @@ Each agent can delegate tasks to the other five, without leaving its own interfa
 ## How it integrates
 
 **Claude Code** gets slash commands:
-```
+```text
 /opencode:run refactor the auth module
 /gemini:review check this diff for edge cases
 /codex:run write tests for the new retry logic
@@ -45,7 +46,7 @@ Each agent can delegate tasks to the other five, without leaving its own interfa
 ```
 
 **OpenCode** gets MCP tools:
-```
+```text
 delegate_claude("review this migration for data loss risk")
 delegate_gemini("analyze this for performance bottlenecks")
 delegate_codex("add integration tests")

--- a/_posts/2026-04-17-chorus-cross-agent-plugin-mesh.md
+++ b/_posts/2026-04-17-chorus-cross-agent-plugin-mesh.md
@@ -3,10 +3,10 @@ layout: post
 title: "chorus: a cross-agent plugin mesh for AI coding CLIs"
 date: 2026-04-17
 category: release-notes
-tags: [AI, chorus, claude-code, opencode, gemini, codex, open-source]
+tags: [AI, chorus, claude-code, opencode, gemini, codex, cursor, kilo, open-source]
 lang: en
 permalink: /blog/2026/04/17/chorus-cross-agent-plugin-mesh/
-description: "chorus is an open-source plugin collection that creates a 4×3 delegation mesh between Claude Code, OpenCode, Gemini CLI, and Codex — without leaving your current interface."
+description: "chorus is an open-source plugin collection that creates a full 6×6 delegation mesh between Claude Code, OpenCode, Gemini CLI, Codex, Cursor, and Kilo — without leaving your current interface."
 image: /assets/images/posts/chorus/infographic-900x530.png
 ---
 
@@ -14,22 +14,24 @@ image: /assets/images/posts/chorus/infographic-900x530.png
 
 Most AI coding tools are designed like islands.
 
-You pick one — Claude Code, OpenCode, Gemini CLI, or Codex — and stay inside its workflow. A second opinion means copying context, switching terminals, re-explaining the task, waiting, comparing answers, and manually carrying the result back.
+You pick one — Claude Code, OpenCode, Gemini CLI, Codex, Cursor, or Kilo — and stay inside its workflow. A second opinion means copying context, switching terminals, re-explaining the task, waiting, comparing answers, and manually carrying the result back.
 
 I built **chorus** to remove that step.
 
 ## What it does
 
-chorus is an open-source plugin collection that creates a **4×3 delegation mesh** between four AI coding CLIs:
+chorus is an open-source plugin collection that creates a **full 6×6 delegation mesh** between six AI coding CLIs:
 
-| From \ To   | Claude | OpenCode | Gemini | Codex |
-|-------------|--------|----------|--------|-------|
-| Claude Code |   —    |  ✅      |  ✅    |  ✅   |
-| OpenCode    |  ✅    |  —       |  ✅    |  ✅   |
-| Gemini CLI  |  ✅    |  ✅      |  —     |  ✅   |
-| Codex       |  ✅    |  ✅      |  ✅    |  —    |
+| From \\ To  | Claude | OpenCode | Gemini | Codex | Cursor | Kilo |
+|-------------|:------:|:--------:|:------:|:-----:|:------:|:----:|
+| Claude Code |   —    |  ✅      |  ✅    |  ✅   |  ✅    |  ✅  |
+| OpenCode    |  ✅    |   —      |  ✅    |  ✅   |  ✅    |  ✅  |
+| Gemini CLI  |  ✅    |  ✅      |   —    |  ✅   |  ✅    |  ✅  |
+| Codex       |  ✅    |  ✅      |  ✅    |   —   |  ✅    |  ✅  |
+| Cursor      |  ✅    |  ✅      |  ✅    |  ✅   |   —    |  ✅  |
+| Kilo        |  ✅    |  ✅      |  ✅    |  ✅   |  ✅    |   —  |
 
-Each agent can delegate tasks to the other three, without leaving its own interface.
+Each agent can delegate tasks to the other five, without leaving its own interface.
 
 ## How it integrates
 
@@ -38,6 +40,8 @@ Each agent can delegate tasks to the other three, without leaving its own interf
 /opencode:run refactor the auth module
 /gemini:review check this diff for edge cases
 /codex:run write tests for the new retry logic
+/cursor:run check if this fits existing codebase patterns
+/kilo:run review for naming clarity and maintainability
 ```
 
 **OpenCode** gets MCP tools:
@@ -45,21 +49,40 @@ Each agent can delegate tasks to the other three, without leaving its own interf
 delegate_claude("review this migration for data loss risk")
 delegate_gemini("analyze this for performance bottlenecks")
 delegate_codex("add integration tests")
+delegate_cursor("check pattern consistency across the repo")
+delegate_kilo("review for long-term readability")
 ```
 
-**Gemini CLI** and **Codex** get skills — install once, then just ask them to delegate in natural language.
+**Gemini CLI**, **Codex**, **Cursor**, and **Kilo** get skills/rules — install once, then delegate in natural language.
 
 ## The workflow that actually matters
 
-Parallel code review. Ask three different agents to review the same diff independently, each with a different focus:
+Parallel code review. Ask five different agents to review the same diff independently, each with a different focus:
 
 ```text
-/gemini:review — correctness and edge cases
-/codex:run    — test coverage
-/opencode:run — architecture and simplification
+/gemini:review   — correctness and edge cases
+/codex:run       — test coverage and missing cases
+/cursor:run      — codebase integration and pattern consistency
+/kilo:run        — maintainability and naming clarity
+/claude:review   — security and correctness
 ```
 
-Different models have genuinely different failure modes. One may miss an edge case another catches. One may overweight architecture where another spots a missing test. You read all three and make the call. The agents provide the raw material; judgment stays with you.
+Different models have genuinely different failure modes. One may miss an edge case another catches. One may overweight architecture where another spots a missing test. You read all five and make the call. The agents provide the raw material; judgment stays with you.
+
+OpenCode participates in the full 6×6 mesh but is excluded from parallel workflow patterns — its TUI stdout isn't capturable programmatically.
+
+## Named workflow commands
+
+Instead of wiring five separate commands with different prompts each time, chorus ships named workflow patterns as first-class installable plugins:
+
+| Command | What it does |
+|---|---|
+| `/chorus:review` | Parallel review of `git diff HEAD` — one command, 5 independent opinions |
+| `/chorus:council` | Same task to all 5 agents with different roles; host synthesizes |
+| `/chorus:debug` | Ranked root-cause hypotheses from 5 agents for a bug symptom |
+| `/chorus:second-opinion` | Quick independent check from one chosen agent |
+
+OpenCode gets these as MCP tools: `council`, `parallel_review`, `parallel_debug`, `second_opinion`. Gemini CLI, Codex, Cursor, and Kilo get them as skills/rules.
 
 ## Install
 
@@ -69,10 +92,14 @@ claude plugin install https://github.com/valpere/chorus
 
 # OpenCode
 opencode plugin @valpere/chorus-opencode
+
+# Gemini CLI
+gemini skills install https://github.com/valpere/chorus --path for-gemini/claude
+# ... and other agents
 ```
 
-Full installation for Gemini CLI and Codex is in the README.
+Full installation for Codex, Cursor, and Kilo is in the [README](https://github.com/valpere/chorus).
 
-chorus is not trying to be a new IDE or orchestration platform. It is plumbing between tools developers already use. One install, four agents, zero new workflows forced on you.
+chorus is not trying to be a new IDE or orchestration platform. It is plumbing between tools developers already use. One install, six agents, zero new workflows forced on you.
 
 **[https://github.com/valpere/chorus](https://github.com/valpere/chorus)**


### PR DESCRIPTION
## Summary

- Home hero card stats: 4 agents → 6, 12 routes → 30 (6×5)
- Blog post EN: 6×6 mesh table, Cursor/Kilo integration, 5-agent parallel review, named workflow commands section, updated description + tags
- Blog post UA: same updates in Ukrainian