### PR TITLE
Add CV page

### DIFF
--- a/cv.md
+++ b/cv.md
@@ -1,0 +1,252 @@
+---
+layout: page
+title: CV
+permalink: /cv/
+---
+
+# Valentyn Solomko
+
+Senior Software Engineer / CTO
+
+**Links:** [LinkedIn](https://www.linkedin.com/in/valentynsolomko/) · [GitHub](https://github.com/valpere) · [Portfolio](https://valpere.github.io/)
+
+---
+
+## Summary
+
+Seasoned **Senior Software Engineer / Technical Lead** with **20+ years of professional experience** designing and delivering **enterprise-grade software systems** and **AI-driven software solutions**. Expert in **Go** (3+), **Java** (5+), **Groovy** (6+), and **Perl** (20+), with a strong focus on **cloud-native development**, **scalable microservices**, and **data-intensive automation**.
+
+Currently serving as **CTO**, directing technical strategy and AI workflow integration across multi-product SaaS development with a **20+ person engineering team**. Designing and implementing AI-assisted engineering workflows — from spec-driven development and multi-model review pipelines to autonomous refactoring and context-engineered AI agents — that measurably accelerate delivery and reduce defect rates.
+
+Combines deep technical expertise with hands-on leadership: from **architecting scalable APIs and microservices** to **mentoring teams** and **driving modernization initiatives**. Adept at transforming complex legacy platforms into efficient, cloud-native systems through automation, best practices, and strategic design.
+
+**Core Competencies:** Go & Java Specialist · AI/ML Integration · AI-Assisted Development · AI-Powered Pair Programming · Cloud-Native Systems · Automation Engineering · Backend Optimization · DevOps Integration · Microservices · CTO / Executive Engineering Leadership · Team Leadership · Technical Mentorship
+
+---
+
+## Skills
+
+**Backend Development:**
+
+- **Languages:** Go, Java, Groovy, Perl, TypeScript, PL/pgSQL, Bash
+- **Frameworks:**
+  - **Go:** Gin, Cobra + Viper, uber-zap, GORM, gRPC, protobuf, Colly, Goquery, chromedp, testing + mockery
+  - **Java:** Lombok, Spring Boot, Spring Security, Spring Data
+  - **TypeScript / Node:** React 19, Deno, Supabase Edge Functions, Vitest, Playwright
+  - **Perl:** perlcritic, perltidy
+- **Architectural Patterns:** Microservices, Event-Driven Architecture, Domain-Driven Design (DDD), Clean Architecture, SOLID
+- **Concepts:** OOP, Concurrency, API Design, Distributed Systems, Automation Pipelines
+
+**AI, Intelligent Systems & AI-Assisted Development:**
+
+- **Core Areas:** Neural Networks, Deep Learning, Predictive Analytics, Intelligent Automation
+- **Paradigms / Approaches:** AI-Assisted Development · AI-Powered Pair Programming · Generative AI for Specification and Design · AI-Augmented Spec-Driven Development · AI-Driven Development (AIDD) · Autonomous Refactoring · Context Engineering · Self-Healing Systems
+- **Tooling & Platforms:** OpenAI API, OpenRouter API, Ollama, Claude Code, Cursor, Aider, Langfuse, Promptfoo
+- **Applications:** AI-assisted automation, smart data extraction, chatbot intelligence, decision support systems, multi-model review pipelines
+- **Integrations:** Embedding AI workflows into backend pipelines and SaaS platforms; multi-provider LLM failover (Anthropic, OpenAI, Google, Ollama, OpenRouter)
+
+**Cloud & DevOps Engineering:**
+
+- **Cloud Platforms:** Google Cloud Platform (GCP), Google Kubernetes Engine (GKE), OpenShift
+- **Containerization & Orchestration:** Docker, Kubernetes
+- **Infrastructure as Code:** Terraform, Ansible, Helm
+- **CI/CD:** CloudBees CI (Jenkins), CloudBees SDA (ElectricFlow), GitHub Actions, GitLab CI/CD
+- **Artifact Management:** JFrog Artifactory, Nexus
+- **Monitoring & Reliability:** Prometheus, Grafana, Langfuse (LLM observability), centralized logging (ELK, uber-zap)
+- **Deployment:** GitHub Pages, Railway, Fly.io, Vercel, Supabase, Upstash
+
+**Data & Storage Systems:**
+
+- **Relational:** PostgreSQL / Supabase, MySQL, SQLite, Interbase / Firebird — SQL optimization, RLS policies, multi-tenant schema design
+- **NoSQL / Key-Value:** MongoDB, Redis / Upstash, BerkeleyDB, LevelDB
+- **Focus:** Schema design, performance tuning, high availability, caching strategies
+
+**System Design & Architecture:**
+
+- **Domains:** Distributed Systems, High Availability, API Gateways, Event Processing, Fault Tolerance, Load Balancing
+- **Web Infrastructure:** Apache, Nginx, Load Balancing, Security Hardening
+- **Operating Systems:** Linux (CentOS, Ubuntu), FreeBSD, Windows
+- **Design Patterns:** SOLID, Clean Architecture, Domain-Driven Design, UML modeling
+
+**Version Control & Tooling:**
+
+- **VCS:** Git (GitHub, GitLab, Bitbucket), SVN, CVS
+- **Project Tools:** Jira, ClickUp, Confluence, Gradle, Postman, UML, GraphViz, yEd, VSCode, IntelliJ IDEA, Geany
+- **Bot Development:** Telegram, Discord, WhatsApp, SMS/Voice (autoresponders, crypto bots, e-commerce)
+- **Web Scraping:** Anti-detection, Captcha-solving, Proxy rotation, Distributed processing, Intelligent ETL Pipelines
+
+**Leadership & Collaboration:**
+
+- **Roles:** CTO, Technical Lead, Architecture Advisor, Mentor
+- **Practices:** Agile Scrum, After Action Review, Technical Documentation Standards, AI Workflow Engineering
+- **Impact:** Led 20+ person engineering teams; improved developer efficiency through AI-assisted workflows; delivered multi-product SaaS platforms with measurable reliability gains
+
+---
+
+## Employment History
+
+### Freelance Software Engineer | Self-employed | Remote | Oct 2024 — Present
+
+**Technical Leadership & AI Workflow Integration:**
+
+- Serve as CTO for AI-driven SaaS product company, directing engineering strategy across multiple products with a 20+ person team
+- Design and implement AI-assisted engineering workflows: spec-driven development, multi-model PR review pipelines, context-engineered AI agents, autonomous quality gates
+- Architect multi-product SaaS platforms: React 19 + TypeScript frontends, Deno/Supabase Edge Functions, multi-provider LLM failover with Langfuse observability
+
+**Backend Development & Architecture:**
+
+- Design and implement scalable backend systems using Go, Java, Groovy, and Perl
+- Develop RESTful APIs and microservices architectures for high-performance applications
+- Create custom CLI tools and enterprise-grade software solutions
+- Optimize database performance and design efficient data storage solutions
+
+**AI-Assisted Development & AI Integration:**
+
+- AI coding platforms: Claude Code, Cursor, Aider, Lovable AI, Replit
+- Multi-provider LLM integration and failover (Anthropic, OpenAI, Google, Ollama, OpenRouter)
+- LLM observability with Langfuse; model evaluation with Promptfoo
+- Deployment: GCP, GitHub Pages, Railway, Fly.io, Vercel, Docker, Kubernetes
+
+**Telegram Bot Development & Automation:**
+
+- Design and develop high-performance Telegram bots using JavaScript, Go, and Java
+- Build autoresponder systems, crypto trading bots, and specialized bots (E-commerce, Crypto/DeFi, Healthcare, Real estate)
+- Implement security features including encryption, user verification, and anti-spam measures
+- Deploy bots with Docker containerization on GCP with comprehensive monitoring
+
+**Data Extraction & Web Scraping:**
+
+- Develop advanced web scraping tools with anti-detection and captcha-solving capabilities
+- Create automated data extraction pipelines with YAML/JSON configurations
+- Build distributed processing systems for large-scale data collection projects
+
+---
+
+### Senior Plugin Developer | CloudBees Inc. | Remote | 2019 — 2024
+
+- Engineered enterprise-grade plugins for CloudBees DevOps platform focusing on Analytics, CI/CD, and Release Orchestration
+- Spearheaded major system refactoring initiative creating reusable component packages and Chrome extension
+- Architected and implemented core platform components improving system scalability
+- Led requirements gathering through direct customer collaboration; conducted technical interviews
+- Established Agile SCRUM practices improving team delivery efficiency
+
+**Technical Environment:** Groovy, Java, Perl, Go · Docker, Kubernetes, Helm, Ansible, Terraform · CloudBees CI (Jenkins), CloudBees SDA (ElectricFlow), GitLab CI · JFrog Artifactory, Nexus · Git (GitHub, GitLab, Bitbucket)
+
+---
+
+### Plugin Developer | Electric Cloud Inc. (acquired by CloudBees) | Remote | 2018 — 2019
+
+- Led plugin development within the Flow Plugin team for enterprise DevOps automation platform
+- Engineered and maintained custom plugins extending platform functionality for Fortune 500 clients
+- Developed comprehensive integration test suites ensuring plugin reliability and performance
+
+**Technical Environment:** Groovy, Perl · Electric Flow (now CloudBees CD) · Docker, Kubernetes · Agile Development
+
+---
+
+### Team Lead, Kyiv Branch | PortaOne LLC | Kyiv, Ukraine | 2013 — 2018
+
+- Led development team building core components for PortaSwitch BSS and Billing platform
+- Architected and implemented telecommunications solutions for MNO/MVNO/MVNE providers
+- Established "After Action Review" process improving team performance and project outcomes
+- Mentored junior developers; facilitated cross-departmental collaboration
+- Managed integration of VoIP, IoT, and broadband service components
+
+**Technical Environment:** Perl, Linux, PortaSwitch · MySQL, PostgreSQL · VoIP, SIP, BSS · Git · Agile, After Action Review
+
+---
+
+### System Architect & Development Head | Internet Invest, Ltd | Kyiv, Ukraine | 2010 — 2013
+
+- Architected and led complete redesign of enterprise email service platform: mail.ua
+- Managed backend development department overseeing 20+ engineers
+- Established comprehensive development lifecycle including design, coding, and testing standards
+- Created automated testing and deployment pipelines reducing delivery time
+
+**Technical Environment:** Perl, Shell Scripting · MySQL, PostgreSQL · Linux, Apache · SMTP, POP3, IMAP · SVN, Redmine
+
+---
+
+### CEO/CTO | TVCom, Ltd (Value Added Service Provider) | Kyiv, Ukraine | 2008 — 2010
+
+- Led company-wide crisis management and digital transformation initiatives
+- Executed comprehensive IT department restructuring optimizing operational efficiency
+- Redesigned SMS/MMS gateway systems; modernized VoIP service architecture; optimized high-traffic WAP/Web platforms
+
+**Technical Environment:** SMS, MMS, VoIP, WAP · SMPP, MM7, SIP, HTTP · Linux, Asterisk, OpenVZ · MySQL, PostgreSQL
+
+---
+
+### Department Head | Net Style (Value Added Service Provider) | Kyiv, Ukraine | 2007 — 2008
+
+- Established structured software development processes and methodologies
+- Architected and deployed mobile Value Added Service Provider (VASP) platforms
+- Designed and implemented enterprise telephony solutions using Asterisk IP PBX
+- Created intelligent IVR services framework for telecommunications
+
+**Technical Environment:** Perl, Shell Scripting · Asterisk IP PBX, SIP · VASP Platforms, SMS/MMS · Linux, MySQL, PostgreSQL
+
+---
+
+### Senior Developer | Sunny Mobile (Value Added Service Provider) | Kyiv, Ukraine | 2006 — 2007
+
+- Architected and implemented SMS/MMS traffic control systems handling millions of messages daily
+- Developed control systems integrating multiple protocols (SMPP, SMTP, HTTP, MM4)
+- Created interactive SMS service platform for real-time customer engagement
+- Designed Device Management System (DMS) for high-load WAP portals
+
+**Technical Environment:** Perl, Shell Scripting · SMPP, SMTP, HTTP, MM4 · SMS/MMS Gateway · Linux, MySQL, PostgreSQL
+
+---
+
+### Technical Architect & Team Lead | Summit, CJSC | Kyiv, Ukraine | 1997 — 2006
+
+- Architected and implemented enterprise-wide distributed systems: workflow management platform, logistics automation system, accounting integration framework
+- Designed and developed internal document management system serving 500+ users
+- Led successful migration of mission-critical workflows from Windows to Linux
+- Maintained 24/7 availability of business-critical systems; reduced operational costs through platform standardization
+
+**Technical Environment:** Delphi, Perl, Shell Scripting · Linux, Windows · Interbase · Distributed Systems, Workflow Automation · CVS
+
+---
+
+## Education
+
+**NPDU** | Kyiv, Ukraine | Bachelor's degree, Physics & Astronomy
+
+---
+
+## Languages
+
+- **English:** Professional working proficiency (B2)
+- **Ukrainian:** Native proficiency
+
+---
+
+## Licenses & Certifications
+
+- [Neural Networks and Deep Learning — Coursera](https://www.coursera.org/account/accomplishments/certificate/PVUQY7RSBMRY)
+- [The Complete Java Certification Course — Udemy](https://www.udemy.com/certificate/UC-4674ebc7-cf9c-4e44-b2bb-f1074b1426e0/)
+- [Google Cloud Platform (GCP) Fundamentals for Beginners — Udemy](https://www.udemy.com/certificate/UC-9287a673-4411-45fc-8a2c-11ffa1d907fc/)
+- [Scrum Certification Prep — Udemy](https://www.udemy.com/certificate/UC-935e89f6-5964-4082-8473-5ae463c0efd1/)
+- [Ansible for the Absolute Beginner — Udemy](https://www.udemy.com/certificate/UC-a4cfb1a8-8280-4b10-b532-71f297f74f01/)
+- [Ansible Advanced — Udemy](https://www.udemy.com/certificate/UC-318ca9ce-3b45-4afe-8ffe-4035216a595e/)
+- [Building Cloud Infrastructure with Terraform — Udemy](https://www.udemy.com/certificate/UC-c8e63458-669f-4568-aadd-770f1b54a909/)
+- [Kubernetes for the Absolute Beginners — Udemy](https://www.udemy.com/certificate/UC-c58dbc9c-5e05-4219-a9f7-cda4dc42a6d5/)
+- [Docker for the Absolute Beginner — Udemy](https://www.udemy.com/certificate/UC-8a423965-6dbb-40a2-8d06-5eb03ed683c5/)
+- [OpenShift for the Absolute Beginners — Udemy](https://www.udemy.com/certificate/UC-3df8b2ba-86d5-4a7f-8607-97d04a8fa02f/)
+- [Gradle Fundamentals — Udemy](https://www.udemy.com/certificate/UC-f7794cec-9d06-4866-9b36-c41abd94dab6/)
+- [Learning Go — LinkedIn](https://www.linkedin.com/learning/certificates/222f64e887de828042781219222d9db3fdf0b516baa442709d85a3138e54ad25)
+- [Learning the Go Standard Library — LinkedIn](https://www.linkedin.com/learning/certificates/ffe9a1ad6719c93b0d4928759410959f1895c103d286140eeba6736e86c350fd)
+- [Generics in Go — LinkedIn](https://www.linkedin.com/learning/certificates/fa7c9bea463e3c2e241bc66d4b08f63095068f827330587244e3004af1cdc8e1)
+- [Applied Concurrency in Go — LinkedIn](https://www.linkedin.com/learning/certificates/5439703c5ace4d6bc9a3eebff267f9e70744013834ce64f60b2cbb349cbce)
+- [Programming Foundations: Design Patterns — LinkedIn](https://www.linkedin.com/learning/certificates/96c12269d0817fe7fb05839d0a1c5976242a719274628cbee97794467d8e428d)
+- [Go Design Patterns — LinkedIn](https://www.linkedin.com/learning/certificates/02fd19785b260f5ca19d4b842919c67cd85c209dbde19f6e744148a11c2144f5)
+- [Advanced Design Patterns: Design Principles — LinkedIn](https://www.linkedin.com/learning/certificates/784bec4758be2ecc488235fca3a757f8328c44a2848a7b6a0f9c9aa72c8c1f82)
+- [Design Patterns: Creational — LinkedIn](https://www.linkedin.com/learning/certificates/d8defbbf85e9d61c65ffd3eaac34385a41c5816d70a0235f33085d20b0850c71)
+- [Software Design: Modeling with UML — LinkedIn](https://www.linkedin.com/learning/certificates/a3191d293391c57ddb5ee5b2870267822b713fd01388efb6e276ab948b0b0d91)
+- [Programming Foundations: Object-Oriented Design — LinkedIn](https://www.linkedin.com/learning/certificates/45df3b4a0fb1863eb0ec9b5a2db59699cdc65941ad47a59fa9d2003c7c8f8399)
+- [Learning SOLID Programming Principles — LinkedIn](https://www.linkedin.com/learning/certificates/ca940ea1e2da8230f99345bc7ab731a397557a61826700231a95bc2f4d5ebf9c)
+- [Software Architecture: Patterns for Developers — LinkedIn](https://www.linkedin.com/learning/certificates/ee93921afcef6a897c07629a13985ed86780c9d7e3032613e2940c6d7d0b4b3c)
+- [Learning Java 11 — LinkedIn](https://www.linkedin.com/learning/certificates/3ce532549d1394815d3384ad465cd1e6425ce28b840acd1ddf7b6c52664175df)
+- [Java 17: First Look — LinkedIn](https://www.linkedin.com/learning/certificates/80ad67760dc0f6267398565a277e351ccd18527732ea1087d9566ee2c5b18a2f)


### PR DESCRIPTION
## Summary

- Adds `/cv/` page from LinkedIn CV export
- Strips all personal contact info (email, phone, WhatsApp, Signal)
- Keeps public links: LinkedIn, GitHub, portfolio URL
- Removes Pandoc `[]{#anchor}` artifacts; cleans formatting
- 9 employment positions (1997–present), full skills, education, 25 certifications

## Test Plan

- [ ] Site builds without errors (`bundle exec jekyll build`)
- [ ] `/cv/` page renders and is reachable in nav
- [ ] No personal contact info present (email, phone, WhatsApp, Signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)