### PR TITLE
Update CV page: 2026-06-11 improvements

### DIFF
--- a/cv.md
+++ b/cv.md
@@ -6,7 +6,7 @@ permalink: /cv/
 
 # Valentyn Solomko
 
-Senior Software Engineer / CTO
+Senior Software Engineer / Technical Lead / CTO
 
 **Links:** [LinkedIn](https://www.linkedin.com/in/valentynsolomko/) · [GitHub](https://github.com/valpere) · [Portfolio](https://valpere.github.io/)
 
@@ -14,205 +14,235 @@ Senior Software Engineer / CTO
 
 ## Summary
 
-Seasoned **Senior Software Engineer / Technical Lead** with **20+ years of professional experience** designing and delivering **enterprise-grade software systems** and **AI-driven software solutions**. Expert in **Go** (3+), **Java** (5+), **Groovy** (6+), and **Perl** (20+), with a strong focus on **cloud-native development**, **scalable microservices**, and **data-intensive automation**.
+Seasoned **Senior Software Engineer / Technical Lead** with **20+ years of professional experience** designing and delivering enterprise-grade software systems and AI-driven products. Expert in **Go** (3+), **Java** (5+), **Groovy** (6+), and **Perl** (20+), with a strong focus on cloud-native development, scalable microservices, and data-intensive automation.
 
-Currently serving as **CTO**, directing technical strategy and AI workflow integration across multi-product SaaS development with a **20+ person engineering team**. Designing and implementing AI-assisted engineering workflows — from spec-driven development and multi-model review pipelines to autonomous refactoring and context-engineered AI agents — that measurably accelerate delivery and reduce defect rates.
+Currently serving as **CTO**, directing technical strategy and AI workflow integration across multi-product SaaS development with a **20+ person engineering team**. Designs and implements AI-assisted engineering workflows — from spec-driven development and multi-model review pipelines to autonomous refactoring and context-engineered AI agents — that measurably accelerate delivery and reduce defect rates.
 
-Combines deep technical expertise with hands-on leadership: from **architecting scalable APIs and microservices** to **mentoring teams** and **driving modernization initiatives**. Adept at transforming complex legacy platforms into efficient, cloud-native systems through automation, best practices, and strategic design.
+Recently delivered, as a solo engineer, two production AI systems end-to-end: a conversational RAG platform that automates document generation (100% artefact validity, ~$7/user/month) and a voice AI agent handling ~20,000 support calls per month at ~80% automation. Combines deep technical expertise with hands-on leadership — from architecting scalable APIs and microservices to mentoring teams and driving modernization initiatives. Adept at transforming complex legacy platforms into efficient, cloud-native systems through automation, best practices, and strategic design.
 
-**Core Competencies:** Go & Java Specialist · AI/ML Integration · AI-Assisted Development · AI-Powered Pair Programming · Cloud-Native Systems · Automation Engineering · Backend Optimization · DevOps Integration · Microservices · CTO / Executive Engineering Leadership · Team Leadership · Technical Mentorship
+Strong cross-functional communicator and problem-solver, passionate about system performance, software quality, and developer productivity.
+
+**Core Competencies:** Go & Java Specialist · AI/ML Integration · AI-Assisted Development · AI-Powered Pair Programming · AI-Augmented Spec-Driven Development · RAG & LLM Integration · Cloud-Native Systems · Automation Engineering · Backend Optimization · DevOps Integration · Microservices · CTO / Executive Engineering Leadership · Team Leadership · Technical Mentorship
 
 ---
 
 ## Skills
 
-**Backend Development:**
+**Backend Development**
 
 - **Languages:** Go, Java, Groovy, Perl, TypeScript, PL/pgSQL, Bash
 - **Frameworks:**
-  - **Go:** Gin, Cobra + Viper, uber-zap, GORM, gRPC, protobuf, Colly, Goquery, chromedp, testing + mockery
+  - **Go:** Gin, Cobra + Viper, uber-zap, GORM, sqlc + pgx, gRPC, protobuf, Colly, Goquery, chromedp, river, testing + mockery
   - **Java:** Lombok, Spring Boot, Spring Security, Spring Data
   - **TypeScript / Node:** React 19, Deno, Supabase Edge Functions, Vitest, Playwright
   - **Perl:** perlcritic, perltidy
 - **Architectural Patterns:** Microservices, Event-Driven Architecture, Domain-Driven Design (DDD), Clean Architecture, SOLID
-- **Concepts:** OOP, Concurrency, API Design, Distributed Systems, Automation Pipelines
+- **Concepts:** OOP, Concurrency, API Design, Distributed Systems, Automation Pipelines, Idempotency & Two-Phase Transactions
 
-**AI, Intelligent Systems & AI-Assisted Development:**
+**AI, Intelligent Systems & AI-Assisted Development**
 
-- **Core Areas:** Neural Networks, Deep Learning, Predictive Analytics, Intelligent Automation
-- **Paradigms / Approaches:** AI-Assisted Development · AI-Powered Pair Programming · Generative AI for Specification and Design · AI-Augmented Spec-Driven Development · AI-Driven Development (AIDD) · Autonomous Refactoring · Context Engineering · Self-Healing Systems
-- **Tooling & Platforms:** OpenAI API, OpenRouter API, Ollama, Claude Code, Cursor, Aider, Langfuse, Promptfoo
-- **Applications:** AI-assisted automation, smart data extraction, chatbot intelligence, decision support systems, multi-model review pipelines
-- **Integrations:** Embedding AI workflows into backend pipelines and SaaS platforms; multi-provider LLM failover (Anthropic, OpenAI, Google, Ollama, OpenRouter)
+- **Core Areas:** Neural Networks, Deep Learning, Retrieval-Augmented Generation (RAG), Predictive Analytics, Intelligent Automation
+- **Paradigms / Approaches:** AI-Assisted Development; AI-Powered Pair Programming; Generative AI for Specification and Design; AI-Augmented Spec-Driven Development; AI-Driven Development (AIDD); Autonomous Refactoring and Adaptive Coding; AI-Agent-Driven Development; Context Engineering; Self-Healing Systems
+- **Tooling & Platforms:** OpenAI API, Anthropic API, OpenRouter, Ollama (local models), Claude Code, Cursor, Aider, Langfuse, Promptfoo
+- **RAG & Vector Search:** pgvector (HNSW), local embeddings (bge-m3), schema-validated LLM function-calling, multi-tenant retrieval
+- **Applications:** AI-assisted automation, smart data extraction, conversational document generation, voice agents, decision-support systems, multi-model review pipelines
+- **Integrations:** Embedding AI workflows into backend pipelines and SaaS platforms; multi-provider LLM failover (Anthropic, OpenAI, Google, Ollama, OpenRouter); LLM cost optimization
 
-**Cloud & DevOps Engineering:**
+**Cloud & DevOps Engineering**
 
-- **Cloud Platforms:** Google Cloud Platform (GCP), Google Kubernetes Engine (GKE), OpenShift
-- **Containerization & Orchestration:** Docker, Kubernetes
+- **Cloud Platforms:** Google Cloud Platform (GCP), Google Kubernetes Engine (GKE), OpenShift, Hetzner
+- **Containerization & Orchestration:** Docker, Docker Compose, Kubernetes
 - **Infrastructure as Code:** Terraform, Ansible, Helm
 - **CI/CD:** CloudBees CI (Jenkins), CloudBees SDA (ElectricFlow), GitHub Actions, GitLab CI/CD
 - **Artifact Management:** JFrog Artifactory, Nexus
-- **Monitoring & Reliability:** Prometheus, Grafana, Langfuse (LLM observability), centralized logging (ELK, uber-zap)
-- **Deployment:** GitHub Pages, Railway, Fly.io, Vercel, Supabase, Upstash
+- **Monitoring & Reliability:** Prometheus, Grafana, OpenTelemetry, Loki, Tempo, Langfuse (LLM observability), centralized logging (ELK, uber-zap)
+- **Secrets & Security:** SOPS + age, Trivy, security hardening
+- **Deployment:** GitHub Pages, Railway, Fly.io, Vercel, Supabase, Upstash, Caddy + Let's Encrypt
+- **Troubleshooting:** metrics, alerts, monitoring, profiling
 
-**Data & Storage Systems:**
+**Data & Storage Systems**
 
 - **Relational:** PostgreSQL / Supabase, MySQL, SQLite, Interbase / Firebird — SQL optimization, RLS policies, multi-tenant schema design
 - **NoSQL / Key-Value:** MongoDB, Redis / Upstash, BerkeleyDB, LevelDB
 - **Focus:** Schema design, performance tuning, high availability, caching strategies
 
-**System Design & Architecture:**
+**System Design & Architecture**
 
 - **Domains:** Distributed Systems, High Availability, API Gateways, Event Processing, Fault Tolerance, Load Balancing
 - **Web Infrastructure:** Apache, Nginx, Load Balancing, Security Hardening
 - **Operating Systems:** Linux (CentOS, Ubuntu), FreeBSD, Windows
-- **Design Patterns:** SOLID, Clean Architecture, Domain-Driven Design, UML modeling
+- **Design Competence:** UML modeling, architectural documentation, system refactoring, finite state machines
+- **Design Patterns:** SOLID, Clean Architecture, Domain-Driven Design
 
-**Version Control & Tooling:**
+**Version Control & Tooling**
 
 - **VCS:** Git (GitHub, GitLab, Bitbucket), SVN, CVS
 - **Project Tools:** Jira, ClickUp, Confluence, Gradle, Postman, UML, GraphViz, yEd, VSCode, IntelliJ IDEA, Geany
 - **Bot Development:** Telegram, Discord, WhatsApp, SMS/Voice (autoresponders, crypto bots, e-commerce)
-- **Web Scraping:** Anti-detection, Captcha-solving, Proxy rotation, Distributed processing, Intelligent ETL Pipelines
+- **Web Scraping:** Anti-detection, captcha-solving, proxy rotation, distributed processing, information retrieval, intelligent ETL pipelines
 
-**Leadership & Collaboration:**
+**Leadership & Collaboration**
 
 - **Roles:** CTO, Technical Lead, Architecture Advisor, Mentor
 - **Practices:** Agile Scrum, After Action Review, Technical Documentation Standards, AI Workflow Engineering
+- **Project Delivery:** Requirements analysis, architecture documentation, cross-functional collaboration
+- **Strengths:** Team enablement, code quality governance, stakeholder communication, delivery excellence
 - **Impact:** Led 20+ person engineering teams; improved developer efficiency through AI-assisted workflows; delivered multi-product SaaS platforms with measurable reliability gains
 
 ---
 
 ## Employment History
 
-### Freelance Software Engineer | Self-employed | Remote | Oct 2024 — Present
+### Freelance Software Engineer & CTO | Self-employed | Remote | Oct 2024 – Present
 
-**Technical Leadership & AI Workflow Integration:**
+Technical leadership and hands-on delivery of AI-driven backend systems. Serve as CTO for an AI-driven SaaS product company, directing engineering strategy across multiple products with a 20+ person team, while delivering selected client engagements end-to-end.
 
-- Serve as CTO for AI-driven SaaS product company, directing engineering strategy across multiple products with a 20+ person team
+**Technical Leadership & AI Workflow Integration**
+
+- Direct engineering strategy across multiple products with a 20+ person team
 - Design and implement AI-assisted engineering workflows: spec-driven development, multi-model PR review pipelines, context-engineered AI agents, autonomous quality gates
-- Architect multi-product SaaS platforms: React 19 + TypeScript frontends, Deno/Supabase Edge Functions, multi-provider LLM failover with Langfuse observability
+- Architect multi-product SaaS platforms: React 19 + TypeScript frontends, Deno / Supabase Edge Functions, multi-provider LLM failover with Langfuse observability
 
-**Backend Development & Architecture:**
+**Selected Projects & Outcomes**
+
+- **AI Application Assistant — Conversational RAG / GovTech platform (2026).** Sole architect, engineer, and DevOps; 8-week MVP + 2-week calibration.
+  - Go monolith (9 subsystems, single binary) on Hetzner, Telegram bot front end, deployed via Docker Compose
+  - Retrieval-augmented generation with pgvector (HNSW) and **local Ollama bge-m3 embeddings** — keeping applicant data on-premise and retrieval resilient to cloud-LLM outages; OpenRouter (Claude / Gemini) for generation
+  - LLM function-calling with schema validation extracts structured facts and fills Excel templates **while preserving interdependent formula chains** (excelize)
+  - 12-state conversation FSM persisted in PostgreSQL; idempotent LLM calls via a two-phase transaction pattern (no duplicate billing or file generation on retry)
+  - Spec-first delivery, reviewed through a multi-model AI pipeline (Claude, Gemini, GPT-4o, DeepSeek, Grok) producing dozens of ADRs before implementation
+  - **Outcomes:** 100% Excel artefact validity, 22% escalation rate, p95 response 10.6s, ~$7 per user/month, delivered on schedule
+- **AI Voice Agent — Customer support automation (2026).** Backend and AI integration; 24-day delivery.
+  - Voice support pipeline: Binotel telephony webhooks → OpenAI Whisper (STT) → GPT-4o-mini function-calling → CRM actions → ElevenLabs / Azure TTS
+  - Redis session state across stateless webhooks; per-scenario state machines; a strict structured action set as LLM guardrails; pre-recorded + real-time TTS hybrid to eliminate latency
+  - **Outcomes:** handled ~20,000 calls/month at ~80% resolution without an operator; operating cost ~$400–700/month
+- **AI Agent Cost Optimization (2026).** Cut AI subagent spend **70–85%** with a hybrid architecture — cheap OpenRouter models for analytical tasks, Claude Haiku as orchestrator, premium models reserved for high-blast-radius work — with multi-provider failover and pinned model IDs, holding quality on structured tasks.
+- **Open-source & client tooling.** Go-based web scraping framework with anti-detection and distributed processing (DataScrapexter); production Telegram bots (weather intelligence, CRM automation, e-commerce); cross-agent AI orchestration mesh (chorus); email validation and marketing automation CLIs.
+
+**Backend Development & Architecture**
 
 - Design and implement scalable backend systems using Go, Java, Groovy, and Perl
-- Develop RESTful APIs and microservices architectures for high-performance applications
+- Develop RESTful APIs and microservices for high-performance applications
 - Create custom CLI tools and enterprise-grade software solutions
 - Optimize database performance and design efficient data storage solutions
 
-**AI-Assisted Development & AI Integration:**
+**Deployment & Data**
 
-- AI coding platforms: Claude Code, Cursor, Aider, Lovable AI, Replit
-- Multi-provider LLM integration and failover (Anthropic, OpenAI, Google, Ollama, OpenRouter)
-- LLM observability with Langfuse; model evaluation with Promptfoo
-- Deployment: GCP, GitHub Pages, Railway, Fly.io, Vercel, Docker, Kubernetes
-
-**Telegram Bot Development & Automation:**
-
-- Design and develop high-performance Telegram bots using JavaScript, Go, and Java
-- Build autoresponder systems, crypto trading bots, and specialized bots (E-commerce, Crypto/DeFi, Healthcare, Real estate)
-- Implement security features including encryption, user verification, and anti-spam measures
-- Deploy bots with Docker containerization on GCP with comprehensive monitoring
-
-**Data Extraction & Web Scraping:**
-
-- Develop advanced web scraping tools with anti-detection and captcha-solving capabilities
-- Create automated data extraction pipelines with YAML/JSON configurations
-- Build distributed processing systems for large-scale data collection projects
+- Databases: PostgreSQL / Supabase, MySQL, MongoDB, Redis / Upstash
+- Deployment: GCP, Hetzner, GitHub Pages, Railway, Fly.io, Vercel, Docker, Kubernetes
 
 ---
 
-### Senior Plugin Developer | CloudBees Inc. | Remote | 2019 — 2024
+### Senior Plugin Developer | CloudBees Inc. | Remote | 2019 – 2024
 
-- Engineered enterprise-grade plugins for CloudBees DevOps platform focusing on Analytics, CI/CD, and Release Orchestration
-- Spearheaded major system refactoring initiative creating reusable component packages and Chrome extension
-- Architected and implemented core platform components improving system scalability
-- Led requirements gathering through direct customer collaboration; conducted technical interviews
-- Established Agile SCRUM practices improving team delivery efficiency
+- Engineered enterprise-grade plugins for the CloudBees DevOps platform, focusing on Analytics, CI/CD, and Release Orchestration
+- Spearheaded a major system refactoring initiative, creating reusable component packages and a Chrome extension
+- Architected and implemented core platform components, improving system scalability
+- Led requirements gathering and analysis through direct customer collaboration
+- Optimized code performance and implemented automated testing frameworks
+- Established Agile Scrum practices, improving team delivery efficiency
+- Conducted technical interviews for engineering candidates
+- Maintained effective communication with cross-functional teams and stakeholders
 
-**Technical Environment:** Groovy, Java, Perl, Go · Docker, Kubernetes, Helm, Ansible, Terraform · CloudBees CI (Jenkins), CloudBees SDA (ElectricFlow), GitLab CI · JFrog Artifactory, Nexus · Git (GitHub, GitLab, Bitbucket)
+**Technical Environment:** Groovy, Java, Perl, Go · Docker, Kubernetes, Helm, Ansible, Terraform · CloudBees CI (Jenkins), CloudBees SDA (ElectricFlow), GitLab CI · JFrog Artifactory, Nexus · BigIP, OctopusDeploy · Git (GitHub, GitLab, Bitbucket) · Agile Scrum, Feature Management
 
 ---
 
-### Plugin Developer | Electric Cloud Inc. (acquired by CloudBees) | Remote | 2018 — 2019
+### Plugin Developer | Electric Cloud Inc. (acquired by CloudBees) | Remote | 2018 – 2019
 
-- Led plugin development within the Flow Plugin team for enterprise DevOps automation platform
+- Led plugin development within the Flow Plugin team for an enterprise DevOps automation platform
 - Engineered and maintained custom plugins extending platform functionality for Fortune 500 clients
 - Developed comprehensive integration test suites ensuring plugin reliability and performance
+- Collaborated with distributed teams to maintain continuous integration workflows
 
-**Technical Environment:** Groovy, Perl · Electric Flow (now CloudBees CD) · Docker, Kubernetes · Agile Development
+**Technical Environment:** Groovy, Perl · JUnit, integration testing frameworks · Electric Flow (now CloudBees CD) · Docker, Kubernetes · Git · Agile Development
 
 ---
 
-### Team Lead, Kyiv Branch | PortaOne LLC | Kyiv, Ukraine | 2013 — 2018
+### Team Lead, Kyiv Branch | PortaOne LLC | Kyiv, Ukraine | 2013 – 2018
 
-- Led development team building core components for PortaSwitch BSS and Billing platform
+- Led the development team building core components for the PortaSwitch BSS and Billing platform
 - Architected and implemented telecommunications solutions for MNO/MVNO/MVNE providers
-- Established "After Action Review" process improving team performance and project outcomes
-- Mentored junior developers; facilitated cross-departmental collaboration
+- Established the "After Action Review" process, improving team performance and project outcomes
+- Mentored junior developers, accelerating their technical growth and productivity
+- Facilitated cross-departmental collaboration, streamlining development workflows
 - Managed integration of VoIP, IoT, and broadband service components
+- Directed technical initiatives for Communication Service Provider solutions
 
-**Technical Environment:** Perl, Linux, PortaSwitch · MySQL, PostgreSQL · VoIP, SIP, BSS · Git · Agile, After Action Review
-
----
-
-### System Architect & Development Head | Internet Invest, Ltd | Kyiv, Ukraine | 2010 — 2013
-
-- Architected and led complete redesign of enterprise email service platform: mail.ua
-- Managed backend development department overseeing 20+ engineers
-- Established comprehensive development lifecycle including design, coding, and testing standards
-- Created automated testing and deployment pipelines reducing delivery time
-
-**Technical Environment:** Perl, Shell Scripting · MySQL, PostgreSQL · Linux, Apache · SMTP, POP3, IMAP · SVN, Redmine
+**Technical Environment:** Perl, Linux, PortaSwitch · MySQL, PostgreSQL · VoIP, SIP, BSS · High-availability systems · Git · YouTrack, Confluence · Agile, After Action Review
 
 ---
 
-### CEO/CTO | TVCom, Ltd (Value Added Service Provider) | Kyiv, Ukraine | 2008 — 2010
+### System Architect & Development Head | Internet Invest, Ltd | Kyiv, Ukraine | 2010 – 2013
+
+- Architected and led the complete redesign of the enterprise email service platform mail.ua
+- Managed the backend development department, overseeing 20+ engineers
+- Established a comprehensive development lifecycle including design, coding, and testing standards
+- Implemented a service operations framework improving system reliability and maintenance
+- Led migration to a new architecture, enhancing scalability and performance
+- Created automated testing and deployment pipelines, reducing delivery time
+- Developed technical documentation standards and best practices
+
+**Technical Environment:** Perl, shell scripting · MySQL, PostgreSQL · Linux, Apache · SMTP, POP3, IMAP · Nagios · SVN · Redmine · Waterfall-to-Agile transition
+
+---
+
+### CEO / CTO | TVCom, Ltd (Value-Added Service Provider) | Kyiv, Ukraine | 2008 – 2010
 
 - Led company-wide crisis management and digital transformation initiatives
-- Executed comprehensive IT department restructuring optimizing operational efficiency
-- Redesigned SMS/MMS gateway systems; modernized VoIP service architecture; optimized high-traffic WAP/Web platforms
+- Executed comprehensive IT department restructuring, optimizing operational efficiency
+- Revitalized mission-critical telecommunications infrastructure: redesigned SMS/MMS gateway systems, modernized VoIP service architecture, and optimized high-traffic WAP/Web platforms
+- Established robust documentation and support processes
+- Developed and launched new value-added services, expanding the product portfolio
+- Managed relationships with mobile carriers and technology partners
 
-**Technical Environment:** SMS, MMS, VoIP, WAP · SMPP, MM7, SIP, HTTP · Linux, Asterisk, OpenVZ · MySQL, PostgreSQL
+**Technical Environment:** SMS, MMS, VoIP, WAP, web services · SMPP, MM7, SIP, HTTP · Linux, Asterisk, OpenVZ · MySQL, PostgreSQL · Monit · crisis management, IT restructuring
 
 ---
 
-### Department Head | Net Style (Value Added Service Provider) | Kyiv, Ukraine | 2007 — 2008
+### Department Head | Net Style (Value-Added Service Provider) | Kyiv, Ukraine | 2007 – 2008
 
 - Established structured software development processes and methodologies
-- Architected and deployed mobile Value Added Service Provider (VASP) platforms
+- Architected and deployed mobile Value-Added Service Provider (VASP) platforms
 - Designed and implemented enterprise telephony solutions using Asterisk IP PBX
-- Created intelligent IVR services framework for telecommunications
+- Created an intelligent IVR services framework for telecommunications
+- Led the development team delivering mobile value-added services
+- Streamlined project delivery workflows, improving time-to-market
 
-**Technical Environment:** Perl, Shell Scripting · Asterisk IP PBX, SIP · VASP Platforms, SMS/MMS · Linux, MySQL, PostgreSQL
+**Technical Environment:** Perl, shell scripting · Asterisk IP PBX, SIP · VASP platforms, SMS/MMS · Linux, high availability · MySQL, PostgreSQL · IVR · SDLC, team leadership, resource planning
 
 ---
 
-### Senior Developer | Sunny Mobile (Value Added Service Provider) | Kyiv, Ukraine | 2006 — 2007
+### Senior Developer | Sunny Mobile (Value-Added Service Provider) | Kyiv, Ukraine | 2006 – 2007
 
 - Architected and implemented SMS/MMS traffic control systems handling millions of messages daily
 - Developed control systems integrating multiple protocols (SMPP, SMTP, HTTP, MM4)
-- Created interactive SMS service platform for real-time customer engagement
-- Designed Device Management System (DMS) for high-load WAP portals
+- Created an interactive SMS service platform for real-time customer engagement
+- Designed a Device Management System (DMS) for high-load WAP portals
+- Engineered a remote development environment for distributed team collaboration
+- Optimized mobile terminal parameter management for improved performance
 
-**Technical Environment:** Perl, Shell Scripting · SMPP, SMTP, HTTP, MM4 · SMS/MMS Gateway · Linux, MySQL, PostgreSQL
+**Technical Environment:** Perl, shell scripting · SMPP, SMTP, HTTP, MM4 · SMS/MMS gateways · Linux, high availability · MySQL, PostgreSQL · WAP, HTTP services · high-load systems
 
 ---
 
-### Technical Architect & Team Lead | Summit, CJSC | Kyiv, Ukraine | 1997 — 2006
+### Technical Architect & Team Lead | Summit, CJSC | Kyiv, Ukraine | 1997 – 2006
 
-- Architected and implemented enterprise-wide distributed systems: workflow management platform, logistics automation system, accounting integration framework
-- Designed and developed internal document management system serving 500+ users
-- Led successful migration of mission-critical workflows from Windows to Linux
-- Maintained 24/7 availability of business-critical systems; reduced operational costs through platform standardization
+- Architected and implemented enterprise-wide distributed systems: a workflow management platform, logistics automation system, and accounting integration framework
+- Designed and developed an internal document management system serving 500+ users
+- Led the successful migration of mission-critical workflows from Windows to Linux
+- Managed the development team delivering enterprise solutions
+- Maintained 24/7 availability of business-critical systems
+- Established system monitoring and maintenance protocols
+- Reduced operational costs through platform standardization
 
-**Technical Environment:** Delphi, Perl, Shell Scripting · Linux, Windows · Interbase · Distributed Systems, Workflow Automation · CVS
+**Technical Environment:** Delphi, Perl, shell scripting · Linux, Windows · Interbase · distributed systems · custom DMS · workflow automation, logistics · TCP/IP, client-server · CVS · team leadership
 
 ---
 
 ## Education
 
-**NPDU** | Kyiv, Ukraine | Bachelor's degree, Physics & Astronomy
+**Bachelor's Degree in Physics & Astronomy** — National Pedagogical Dragomanov University (NPDU), Kyiv, Ukraine
 
 ---
 
@@ -228,13 +258,13 @@ Combines deep technical expertise with hands-on leadership: from **architecting 
 - [Neural Networks and Deep Learning — Coursera](https://www.coursera.org/account/accomplishments/certificate/PVUQY7RSBMRY)
 - [The Complete Java Certification Course — Udemy](https://www.udemy.com/certificate/UC-4674ebc7-cf9c-4e44-b2bb-f1074b1426e0/)
 - [Google Cloud Platform (GCP) Fundamentals for Beginners — Udemy](https://www.udemy.com/certificate/UC-9287a673-4411-45fc-8a2c-11ffa1d907fc/)
-- [Scrum Certification Prep — Udemy](https://www.udemy.com/certificate/UC-935e89f6-5964-4082-8473-5ae463c0efd1/)
-- [Ansible for the Absolute Beginner — Udemy](https://www.udemy.com/certificate/UC-a4cfb1a8-8280-4b10-b532-71f297f74f01/)
-- [Ansible Advanced — Udemy](https://www.udemy.com/certificate/UC-318ca9ce-3b45-4afe-8ffe-4035216a595e/)
+- [Scrum Certification Prep: Scrum Master Agile Scrum Training — Udemy](https://www.udemy.com/certificate/UC-935e89f6-5964-4082-8473-5ae463c0efd1/)
+- [Ansible for the Absolute Beginner — Hands-On DevOps — Udemy](https://www.udemy.com/certificate/UC-a4cfb1a8-8280-4b10-b532-71f297f74f01/)
+- [Ansible Advanced — Hands-On DevOps — Udemy](https://www.udemy.com/certificate/UC-318ca9ce-3b45-4afe-8ffe-4035216a595e/)
 - [Building Cloud Infrastructure with Terraform — Udemy](https://www.udemy.com/certificate/UC-c8e63458-669f-4568-aadd-770f1b54a909/)
-- [Kubernetes for the Absolute Beginners — Udemy](https://www.udemy.com/certificate/UC-c58dbc9c-5e05-4219-a9f7-cda4dc42a6d5/)
-- [Docker for the Absolute Beginner — Udemy](https://www.udemy.com/certificate/UC-8a423965-6dbb-40a2-8d06-5eb03ed683c5/)
-- [OpenShift for the Absolute Beginners — Udemy](https://www.udemy.com/certificate/UC-3df8b2ba-86d5-4a7f-8607-97d04a8fa02f/)
+- [Kubernetes for the Absolute Beginners — Hands-on — Udemy](https://www.udemy.com/certificate/UC-c58dbc9c-5e05-4219-a9f7-cda4dc42a6d5/)
+- [Docker for the Absolute Beginner — Hands-On DevOps — Udemy](https://www.udemy.com/certificate/UC-8a423965-6dbb-40a2-8d06-5eb03ed683c5/)
+- [OpenShift for the Absolute Beginners — Hands-on — Udemy](https://www.udemy.com/certificate/UC-3df8b2ba-86d5-4a7f-8607-97d04a8fa02f/)
 - [Gradle Fundamentals — Udemy](https://www.udemy.com/certificate/UC-f7794cec-9d06-4866-9b36-c41abd94dab6/)
 - [Learning Go — LinkedIn](https://www.linkedin.com/learning/certificates/222f64e887de828042781219222d9db3fdf0b516baa442709d85a3138e54ad25)
 - [Learning the Go Standard Library — LinkedIn](https://www.linkedin.com/learning/certificates/ffe9a1ad6719c93b0d4928759410959f1895c103d286140eeba6736e86c350fd)


### PR DESCRIPTION
## Summary
- Add subtitle '/ Technical Lead' to CV title
- Enrich summary with two concrete AI project outcomes with metrics
- Expand Skills: sqlc+pgx, river, RAG/pgvector/bge-m3, OTel/Loki/Tempo, SOPS+age, Trivy, Hetzner, Caddy, Idempotency
- Add Selected Projects & Outcomes to freelance entry (AI App Assistant, AI Voice Agent, Cost Optimization)
- All employment entries: expanded bullets + richer Technical Environment lines
- Education: full NPDU name + Bachelor's Degree title
- Certifications: full Udemy course titles

## Test plan
- [ ] Jekyll build passes
- [ ] /cv/ page renders correctly with no contact info leak (email/phone/WhatsApp/Signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)