### PR TITLE
Fix og:image front matter format

### DIFF
--- a/portfolio/application-assistant.md
+++ b/portfolio/application-assistant.md
@@ -2,10 +2,7 @@
 layout: portfolio-item
 title: "AI Application Assistant — Telegram Bot for GovTech"
 permalink: /portfolio/application-assistant/
-image:
-  path: /portfolio/assets/images/application-assistant/og-card.png
-  width: 1200
-  height: 630
+image: /portfolio/assets/images/application-assistant/og-card.png
 ---
 
 ## Overview

--- a/portfolio/ivr-elevenlabs.md
+++ b/portfolio/ivr-elevenlabs.md
@@ -2,10 +2,7 @@
 layout: portfolio-item
 title: "AI Voice Agent — Micromobility Customer Support"
 permalink: /portfolio/ivr-elevenlabs/
-image:
-  path: /portfolio/assets/images/ivr-elevenlabs/og-card.png
-  width: 1200
-  height: 630
+image: /portfolio/assets/images/ivr-elevenlabs/og-card.png
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- Previous PR used hash format (`image: { path: ... }`) which jekyll-seo-tag 2.8.0 silently ignores
- Switch to simple string format (`image: /path/to/og-card.png`) — verified locally generates correct `og:image` meta tag

## Test plan
- [x] Local build confirmed: `og:image` tag present in `_site/portfolio/application-assistant/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)