### PR TITLE
Fix og:image format (string, not hash)

### DIFF
--- a/portfolio/application-assistant.md
+++ b/portfolio/application-assistant.md
@@ -2,10 +2,7 @@
 layout: portfolio-item
 title: "AI Application Assistant — Telegram Bot for GovTech"
 permalink: /portfolio/application-assistant/
-image:
-  path: /portfolio/assets/images/application-assistant/og-card.png
-  width: 1200
-  height: 630
+image: /portfolio/assets/images/application-assistant/og-card.png
 ---
 
 ## Overview

--- a/portfolio/ivr-elevenlabs.md
+++ b/portfolio/ivr-elevenlabs.md
@@ -2,10 +2,7 @@
 layout: portfolio-item
 title: "AI Voice Agent — Micromobility Customer Support"
 permalink: /portfolio/ivr-elevenlabs/
-image:
-  path: /portfolio/assets/images/ivr-elevenlabs/og-card.png
-  width: 1200
-  height: 630
+image: /portfolio/assets/images/ivr-elevenlabs/og-card.png
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- jekyll-seo-tag 2.8.0 silently ignores the `image: {path:, width:, height:}` hash format
- Simple string `image: /path/to/og-card.png` correctly emits `og:image` meta tag
- Verified locally: tag present in built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)