### PR TITLE
Add session-end/session-recall skills (with 3 upstream bugfixes)

### DIFF
--- a/.claude/hooks/_lib/hook-common.sh
+++ b/.claude/hooks/_lib/hook-common.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Shared logging setup for Claude Code hooks installed via /generate-session-end.
+#
+# Usage: source this file, then call hook_setup_logging "<script-name>"
+# Sets LOG_FILE (global) and redirects stderr to the log + terminal.
+#
+# Log dir is per-project, derived from the repo name so each project's
+# hooks log separately (e.g. session-indexer -> ~/.cache/session-indexer/).
+# Override with HOOK_LOG_DIR.
+
+hook_setup_logging() {
+  local script_name="$1"
+  local project_name
+  project_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")
+  # Never operate on the ~/.cache root itself (e.g. cwd=/ with no git → basename "/" → "/").
+  case "$project_name" in ""|"/"|".") project_name="session-end-hooks" ;; esac
+  LOG_DIR="${HOOK_LOG_DIR:-${HOME}/.cache/${project_name}}"
+  mkdir -p "$LOG_DIR" && chmod 700 "$LOG_DIR"
+  LOG_FILE="$LOG_DIR/hooks.log"
+  exec 2> >(tee -a "$LOG_FILE" >&2)
+  echo "[$(date -Iseconds)] $script_name invoked" >> "$LOG_FILE"
+}

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Stop hook: appends/updates today's entry in .claude/session-log.md.
+#
+# Behaviour:
+#   - Skip if /session-end skill wrote the file within the last 2 hours
+#   - Generate summary: agy (Gemini) → opencode (cloud) → raw excerpt
+#   - If session-log.md already has an entry for today, replace it
+#   - Otherwise append; rotate to keep last 10 entries
+#
+# Output: .claude/session-log.md (gitignored, per-project)
+
+set -uo pipefail
+
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-end.sh"
+
+INPUT=$(cat)
+echo "[$(date -Iseconds)] session-end invoked" >> "$LOG_FILE"
+
+LOG="$(dirname "$0")/../session-log.md"
+TODAY=$(date '+%Y-%m-%d')
+
+# Skip if /session-end skill already ran this session (file modified < 2h ago)
+if [[ -f "$LOG" ]]; then
+  AGE=$(( $(date +%s) - $(stat -c %Y "$LOG" 2>/dev/null || echo 0) ))
+  if [[ $AGE -lt 7200 ]]; then
+    echo "[$(date -Iseconds)] session-end: skill already ran (${AGE}s ago), skipping" >> "$LOG_FILE"
+    exit 0
+  fi
+fi
+
+# Locate session transcript
+TRANSCRIPT=$(echo "$INPUT" | python3 -c \
+  "import json,sys; d=json.load(sys.stdin); print(d.get('transcript_path',''))" 2>/dev/null || echo "")
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+  PROJECT_HASH=$(pwd | sed 's|/|-|g')
+  TRANSCRIPT=$(ls -t "$HOME/.claude/projects/$PROJECT_HASH"/*.jsonl 2>/dev/null | head -1 || echo "")
+fi
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+  echo "[$(date -Iseconds)] session-end: no transcript found, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Extract last 30 exchanges from JSONL
+EXCERPT=$(python3 - "$TRANSCRIPT" <<'PYEOF'
+import json, sys
+
+messages = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            msg = entry.get('message', {})
+            role = msg.get('role', '')
+            content = msg.get('content', '')
+            if role not in ('user', 'assistant'):
+                continue
+            text = ''
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get('type') == 'text':
+                        text += block.get('text', '')
+            elif isinstance(content, str):
+                text = content
+            text = text.strip()
+            if text:
+                messages.append(f"[{role}]: {text[:600]}")
+        except Exception:
+            pass
+
+print('\n\n'.join(messages[-30:]))
+PYEOF
+)
+
+if [[ -z "$EXCERPT" ]]; then
+  echo "[$(date -Iseconds)] session-end: empty transcript, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+PROMPT="Write a session summary. Use exactly this structure (no preamble, start directly with the header):
+
+## $TODAY
+
+### Що зробили
+- completed items
+
+### Поточний стан
+- current branch / open PR / what works / what is broken
+
+### Відкриті питання
+- unresolved questions (omit this section entirely if none)
+
+### Наступні кроки
+- what to pick up next session, in priority order
+
+Rules: 10-20 bullets total, Ukrainian for content, English for code/file names/identifiers.
+
+SESSION TRANSCRIPT:
+$EXCERPT"
+
+# --- LLM call helpers ---
+
+try_agy() {
+  local models=(
+    "Gemini 3.5 Flash (Low)"
+    "Gemini 3.5 Flash (Medium)"
+    "Gemini 3.5 Flash (High)"
+    "Gemini 3.1 Pro (Low)"
+    "Gemini 3.1 Pro (High)"
+  )
+  command -v agy &>/dev/null || return 1
+  for model in "${models[@]}"; do
+    echo "[$(date -Iseconds)] session-end: trying agy model: $model" >> "$LOG_FILE"
+    local result
+    result=$(timeout 45 agy -p --model "$model" <<< "$1" 2>>"$LOG_FILE") && \
+      [[ -n "$result" ]] && { echo "$result"; return 0; }
+  done
+  return 1
+}
+
+# Write excerpt to temp file for opencode --file
+EXCERPT_TMP=$(mktemp /tmp/session-end-excerpt.XXXXXX)
+echo "$EXCERPT" > "$EXCERPT_TMP"
+trap 'rm -f "$EXCERPT_TMP"' EXIT
+
+OPENCODE_MSG="Summarize the session transcript in the attached file. Use exactly this structure (no preamble):
+
+## $TODAY
+
+### Що зробили
+- completed items
+
+### Поточний стан
+- current branch / open PR / what works / what is broken
+
+### Відкриті питання
+- unresolved questions (omit section if none)
+
+### Наступні кроки
+- what to pick up next session
+
+Rules: 10-20 bullets total, Ukrainian for content, English for code/file names."
+
+try_opencode() {
+  local models=(
+    "ollama/glm-5:cloud"
+    "ollama/kimi-k2.5:cloud"
+    "ollama/minimax-m2.5:cloud"
+    "ollama/qwen3-coder-next:cloud"
+  )
+  command -v opencode &>/dev/null || return 1
+  for model in "${models[@]}"; do
+    echo "[$(date -Iseconds)] session-end: trying opencode model: $model" >> "$LOG_FILE"
+    local result
+    result=$(timeout 45 opencode run "$OPENCODE_MSG" \
+      --file "$EXCERPT_TMP" --model "$model" --format json 2>>"$LOG_FILE" | \
+      python3 -c "
+import json,sys
+parts=[]
+for line in sys.stdin:
+    line=line.strip()
+    if not line: continue
+    try:
+        obj=json.loads(line)
+        if obj.get('type')=='text':
+            parts.append(obj['part']['text'])
+    except: pass
+print(''.join(parts))
+") && [[ -n "$result" ]] && { echo "$result"; return 0; }
+  done
+  return 1
+}
+
+# --- Generate summary ---
+
+SUMMARY=""
+
+SUMMARY=$(try_agy "$PROMPT" 2>>"$LOG_FILE") || true
+
+if [[ -z "$SUMMARY" ]]; then
+  SUMMARY=$(try_opencode 2>>"$LOG_FILE") || true
+fi
+
+if [[ -z "$SUMMARY" ]]; then
+  echo "[$(date -Iseconds)] session-end: all LLMs failed, using raw excerpt" >> "$LOG_FILE"
+  SUMMARY="## $TODAY
+
+### Transcript excerpt (auto-summary unavailable)
+
+\`\`\`
+$(echo "$EXCERPT" | head -60)
+\`\`\`"
+fi
+
+# --- Append/update/rotate session-log.md ---
+
+python3 - "$LOG" "$TODAY" "$SUMMARY" <<'PYEOF'
+import sys, re, os
+
+log_file = sys.argv[1]
+today    = sys.argv[2]
+entry    = sys.argv[3].strip()
+max_keep = 10
+
+if not os.path.exists(log_file):
+    with open(log_file, 'w') as f:
+        f.write(entry + '\n')
+    sys.exit(0)
+
+with open(log_file) as f:
+    content = f.read()
+
+# Split on ## YYYY-MM-DD headers; keep each header with its content
+parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', content)
+entries = [p.strip() for p in parts if p.strip()]
+
+today_header = f'## {today}'
+today_idx = next((i for i, e in enumerate(entries) if e.startswith(today_header)), -1)
+if today_idx >= 0:
+    entries.pop(today_idx)
+    entries.append(entry)           # replace today's entry, moved to end
+else:
+    entries.append(entry)           # new day
+
+entries = entries[-max_keep:]    # rotate — freshest write can never be trimmed away
+
+with open(log_file, 'w') as f:
+    f.write('\n\n'.join(entries) + '\n')
+PYEOF
+
+echo "[$(date -Iseconds)] session-end: wrote $(wc -l < "$LOG") lines to $LOG" >> "$LOG_FILE"

--- a/.claude/hooks/session-index.sh
+++ b/.claude/hooks/session-index.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Stop hook: indexes the session transcript into per-project SQLite via
+# session-indexer mine. Runs independently of session-end.sh so it fires
+# even when the summary step exits early (e.g. /session-end already ran).
+
+set -uo pipefail
+
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-index.sh"
+
+INPUT=$(cat)
+
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+    echo "[$(date -Iseconds)] session-index: no transcript, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+if ! command -v session-indexer >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] session-index: session-indexer not in PATH, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+DB="$PROJECT_ROOT/.claude/sessions.db"
+
+echo "[$(date -Iseconds)] session-index: mining $(basename "$TRANSCRIPT") → $DB" >> "$LOG_FILE"
+if session-indexer mine "$TRANSCRIPT" --db "$DB" >> "$LOG_FILE" 2>&1; then
+    echo "[$(date -Iseconds)] session-index: done" >> "$LOG_FILE"
+else
+    echo "[$(date -Iseconds)] session-index: session-indexer exited $?" >> "$LOG_FILE"
+fi

--- a/.claude/hooks/session-last.sh
+++ b/.claude/hooks/session-last.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SessionStart hook: injects the most recent entry from .claude/session-log.md.
+#
+# Skips if the file doesn't exist or is empty. Rotation is count-based
+# (last 10 entries) — no age filtering here.
+
+set -euo pipefail
+
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-last.sh"
+
+INPUT=$(cat)
+echo "[$(date -Iseconds)] session-last invoked" >> "$LOG_FILE"
+
+LOG="$(dirname "$0")/../session-log.md"
+
+if [[ ! -f "$LOG" ]]; then
+  echo "[$(date -Iseconds)] session-last: no session-log.md, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Extract the last ## YYYY-MM-DD entry
+LAST_ENTRY=$(python3 - "$LOG" <<'PYEOF'
+import sys, re
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', content)
+entries = [p.strip() for p in parts if p.strip()]
+if entries:
+    print(entries[-1])
+PYEOF
+)
+
+if [[ -z "$LAST_ENTRY" ]]; then
+  echo "[$(date -Iseconds)] session-last: empty log, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Parse date from entry header (## YYYY-MM-DD) — used only for the age label
+ENTRY_DATE=$(echo "$LAST_ENTRY" | grep -oP '^## \K\d{4}-\d{2}-\d{2}' || echo "")
+if [[ -n "$ENTRY_DATE" ]]; then
+  ENTRY_TS=$(date -d "$ENTRY_DATE" +%s 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  AGE=$(( NOW - ENTRY_TS ))
+  AGE_DAYS=$(( AGE / 86400 ))
+  AGE_HOURS=$(( (AGE % 86400) / 3600 ))
+  AGE_LABEL="${AGE_DAYS}d ${AGE_HOURS}h ago"
+  [[ $AGE_DAYS -eq 0 ]] && AGE_LABEL="${AGE_HOURS}h ago"
+else
+  AGE_LABEL="(date unknown)"
+fi
+
+echo "[$(date -Iseconds)] session-last: injecting last entry ($AGE_LABEL)" >> "$LOG_FILE"
+
+jq -n \
+  --arg ctx "$LAST_ENTRY" \
+  --arg age "$AGE_LABEL" \
+  '{
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: ("Previous session context (" + $age + "):\n\n" + $ctx)
+    }
+  }'

--- a/.claude/hooks/session-recall.sh
+++ b/.claude/hooks/session-recall.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# SessionStart hook: injects semantically relevant past session context.
+# Derives a search query from git branch + recent commits, searches the
+# per-project session index (.claude/sessions.db), and injects matching
+# chunks as additionalContext.
+#
+# Complements session-last.sh (which injects the last structured entry).
+# This hook adds semantic recall across all indexed sessions.
+
+set -uo pipefail
+
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-recall.sh"
+
+if ! command -v session-indexer >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] session-recall: session-indexer not in PATH, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+DB="$PROJECT_ROOT/.claude/sessions.db"
+
+if [[ ! -f "$DB" ]]; then
+    echo "[$(date -Iseconds)] session-recall: no sessions.db yet, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+# Derive search query from git context (branch name + recent commit messages)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's/[_\/-]/ /g' || echo "")
+COMMITS=$(git log --oneline -3 2>/dev/null | cut -d' ' -f2- | tr '\n' ' ' || echo "")
+QUERY="$(printf '%s %s' "$BRANCH" "$COMMITS" | tr -s ' ' | sed 's/^ //;s/ $//')"
+
+if [[ -z "$QUERY" ]]; then
+    echo "[$(date -Iseconds)] session-recall: empty query, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] session-recall: query='${QUERY:0:80}'" >> "$LOG_FILE"
+
+RESULTS=$(session-indexer search "$QUERY" --db "$DB" --limit 5 --json 2>/dev/null || echo "[]")
+
+CONTEXT=$(printf '%s' "$RESULTS" | jq -r '
+  map(.Content = ((.Content // "") | gsub("^\\s+|\\s+$"; "")))
+  | map(select(
+    .Content | test("^(Bash|Read|Write|Edit|Glob|Grep|WebFetch|WebSearch|Agent|Task)\\s*\\{") | not
+  ))
+  | group_by(.SessionDate // "unknown")
+  | map({date: (.[0].SessionDate // "unknown"), chunks: (sort_by(.Score) | reverse | .[0:2])})
+  | sort_by(.date) | reverse | .[0:3]
+  | .[]
+  | "### \(.date)",
+    (.chunks[] | "  [\(.Score | tostring | .[0:5])] \(.Content[0:280])\(if (.Content | length) > 280 then "..." else "" end)"),
+    ""
+' 2>/dev/null | sed 's/[[:space:]]*$//')
+
+if [[ -z "$CONTEXT" ]]; then
+    echo "[$(date -Iseconds)] session-recall: no usable results after filtering" >> "$LOG_FILE"
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] session-recall: injecting context" >> "$LOG_FILE"
+
+jq -n --arg ctx "$CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: ("Relevant past sessions (semantic search):\n\n" + $ctx)
+  }
+}'

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -1,0 +1,161 @@
+# /session-end
+
+Manages `.claude/session-log.md` — a per-project rolling log of session
+summaries, one entry per day, last 10 entries kept (count-based, not age-based).
+
+```
+/session-end          → write today's summary (manual, high quality)
+/session-end show     → print the last entry
+/session-end all      → print all entries (oldest → newest)
+```
+
+---
+
+## /session-end (no args) — write today's summary
+
+Review the current conversation and write today's entry to
+`.claude/session-log.md`. Use this before switching projects or closing
+Claude Code. The Stop hook (if configured) auto-generates a summary on
+exit, but `/session-end` produces better output — full session context,
+not transcript extraction.
+
+If an entry for today already exists it is **replaced**, not duplicated.
+After write, the log is rotated to keep the last 10 entries.
+
+### Entry format
+
+```markdown
+## YYYY-MM-DD
+
+### Що зробили
+- completed item
+
+### Поточний стан
+- current branch / open PR number
+- what is working / what is broken
+
+### Відкриті питання
+- unresolved question (omit section if none)
+
+### Наступні кроки
+- next item, in priority order
+```
+
+Rules: 10–20 bullets total · Ukrainian for content · English for code/files/identifiers · include PR number and branch in Поточний стан · omit Відкриті питання if none.
+
+### Write logic
+
+```python
+import re, os
+from datetime import date
+
+log = '.claude/session-log.md'
+today = str(date.today())
+max_keep = 10
+
+entry = """## {today}
+
+### Що зробили
+- ...
+
+### Поточний стан
+- ...
+
+### Наступні кроки
+- ...""".format(today=today).strip()
+
+# fill in entry content based on current session, then:
+
+if not os.path.exists(log):
+    open(log, 'w').write(entry + '\n')
+else:
+    content = open(log).read()
+    parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', content)
+    entries = [p.strip() for p in parts if p.strip()]
+    today_idx = next((i for i, e in enumerate(entries) if e.startswith(f'## {today}')), -1)
+    if today_idx >= 0:
+        entries.pop(today_idx)
+        entries.append(entry)        # replace today, moved to end
+    else:
+        entries.append(entry)        # new day
+    entries = entries[-max_keep:]    # freshest write can never be trimmed away
+    open(log, 'w').write('\n\n'.join(entries) + '\n')
+```
+
+After writing, report:
+> "Session log updated — `.claude/session-log.md`, entry for {today}."
+
+---
+
+## /session-end show — print last entry
+
+```python
+import re
+
+try:
+    with open('.claude/session-log.md') as f:
+        parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', f.read())
+    entries = [p.strip() for p in parts if p.strip()]
+    print(entries[-1] if entries else '(no entries)')
+except FileNotFoundError:
+    print('No session log found. Run `/session-end` to create one.')
+```
+
+---
+
+## /session-end all — print all entries
+
+```python
+import re
+
+try:
+    with open('.claude/session-log.md') as f:
+        parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', f.read())
+    entries = [p.strip() for p in parts if p.strip()]
+    for e in entries:
+        print(e)
+        print()
+    if entries:
+        dates = [e.split('\n')[0].replace('## ', '') for e in entries]
+        print(f"{len(entries)} entries: {dates[0]} → {dates[-1]}")
+except FileNotFoundError:
+    print('No session log found.')
+```
+
+---
+
+## How the full system works
+
+```
+Session ends (exit / /exit)
+  └─ Stop hook: .claude/hooks/session-end.sh
+       ├─ Skip if /session-end ran within 2h (file mtime check)
+       ├─ Try agy -p            (Gemini 3.5 Flash → 3.1 Pro, cheapest first)
+       ├─ Try opencode run --format json  (ollama/*:cloud models)
+       ├─ Fallback: raw transcript excerpt
+       └─ Rotates session-log.md to last 10 entries (count-based, no age filtering)
+
+Next session opens
+  └─ SessionStart hook: .claude/hooks/session-last.sh
+       ├─ Reads last ## YYYY-MM-DD entry from session-log.md
+       └─ Injects as additionalContext: "Previous session context (Xd Yh ago): ..."
+```
+
+LLM fallback chain (Stop hook), both discovered in this project:
+1. `agy -p` — Gemini 3.5 Flash (Low/Medium/High) → Gemini 3.1 Pro (Low/High)
+2. `opencode run --format json` — `ollama/glm-5:cloud`, `ollama/kimi-k2.5:cloud`, `ollama/minimax-m2.5:cloud`, `ollama/qwen3-coder-next:cloud`
+3. Raw transcript excerpt (fallback if both fail)
+
+Mempalace was removed from this project — `session-end`/`session-recall` are
+the sole session-history mechanism here (per-project-local, git-ignored).
+
+The skill works standalone (without hooks) — you just run `/session-end`
+manually. The hooks add automation.
+
+**Log file**: `.claude/session-log.md` — gitignored (see `.gitignore`).
+
+**Troubleshooting**:
+```bash
+tail -30 ~/.cache/valpere.github.io/hooks.log
+cat .claude/session-log.md
+```

--- a/.claude/skills/session-recall/SKILL.md
+++ b/.claude/skills/session-recall/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: session-recall
+description: "Per-project semantic session history. Indexes Claude session transcripts into a local SQLite DB and injects relevant past context at SessionStart. Replaces mempalace with per-project isolation. Usage: /recall <query>"
+---
+
+# /recall
+
+Searches past sessions for this project using semantic similarity (bge-m3) or
+BM25 keyword fallback. Requires `session-indexer` in PATH and a local
+`.claude/sessions.db` (built by the Stop hook after each session).
+
+```
+/recall <query>          → search and display matching session chunks
+/recall stats            → show index state (sessions, chunks, embeddings)
+```
+
+---
+
+## /recall \<query\>
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+DB="$PROJECT_ROOT/.claude/sessions.db"
+
+if [[ ! -f "$DB" ]]; then
+  echo "No session index found at $DB"
+  echo "The Stop hook (session-index.sh) builds it automatically at session end."
+  echo "Run a session and exit to populate the index, then retry."
+  exit 0
+fi
+
+if ! command -v session-indexer >/dev/null 2>&1; then
+  echo "session-indexer not in PATH. See /generate-session-recall for install instructions."
+  exit 0
+fi
+
+QUERY="$*"
+RESULTS=$(session-indexer search "$QUERY" --db "$DB" --limit 10 --json)
+printf '%s' "$RESULTS" | jq -r '
+  if length == 0 then "No results."
+  else
+    "\(length) result(s):\n",
+    (to_entries[] |
+      "[\(.key + 1)] \(.value.SessionDate) · \(.value.Role)\(
+        if (.value.Content | test("^(Bash|Read|Write|Edit|Glob|Grep|WebFetch|WebSearch|Agent|Task)\\s*\\{"))
+        then " [tool]" else "" end
+      ) · score=\(.value.Score | tostring | .[0:5])",
+      "    \(.value.Content[0:400])\(if (.value.Content | length) > 400 then "..." else "" end)",
+      ""
+    )
+  end
+'
+```
+
+---
+
+## /recall stats
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+DB="$PROJECT_ROOT/.claude/sessions.db"
+
+if [[ ! -f "$DB" ]]; then
+  echo "No session index yet."
+  exit 0
+fi
+
+session-indexer stats --db "$DB"
+```
+
+---
+
+## How the full system works
+
+```
+Session ends (exit / /exit)
+  ├─ session-end.sh    — writes LLM summary to .claude/session-log.md
+  └─ session-index.sh  — mines JSONL transcript → .claude/sessions.db (append-only)
+
+Next session opens
+  ├─ session-last.sh   — injects last session-log.md entry (structured summary)
+  └─ session-recall.sh — searches sessions.db by branch+commit context (semantic)
+```
+
+Both SessionStart hooks fire together — `session-last` gives "what we did last
+time", `session-recall` gives "what's relevant to current work" across all history.
+
+**Database**: `.claude/sessions.db` — per-project SQLite, gitignored, append-only.
+Each session adds chunks; nothing is ever overwritten. This is the key difference
+from mempalace (centralised mutable store that corrupted history).
+
+**Search**: bge-m3 vector embeddings when available (requires Ollama + bge-m3 pull),
+automatic BM25 FTS5 fallback when embeddings are absent.
+
+**Troubleshooting**:
+```bash
+# Check hook logs
+tail -30 ~/.cache/$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")/hooks.log
+
+# Manual index check
+session-indexer stats --db .claude/sessions.db
+
+# Backfill embeddings (if Ollama + bge-m3 available)
+session-indexer embed --db .claude/sessions.db
+```
+
+---
+
+## For orchestrators / subagent prep
+
+Subagents spawned via the Agent tool start cold — no SessionStart hook, no
+shared context, no awareness of this project's `.claude/sessions.db`. If a
+subagent's task would benefit from past decisions or discussions, query
+history yourself *before* spawning it, then fold the relevant results into
+the subagent's prompt (subagent prompts must be self-contained).
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+DB="$PROJECT_ROOT/.claude/sessions.db"
+
+[[ -f "$DB" ]] && command -v session-indexer >/dev/null 2>&1 || exit 0
+
+session-indexer search "<query>" --db "$DB" --limit 5 --json | jq -r '
+  .[] | "[\(.SessionDate) · \(.Role)] \(.Content[0:300])"
+'
+```
+
+Limitations:
+- Subagent tool allowlists (`bug-fixer`, `code-generator`, `tech-lead`, etc.)
+  don't include the `Skill` tool — a spawned subagent can't invoke `/recall`
+  or this skill itself mid-task. This section is for the orchestrator to run
+  *before* spawning, not for the subagent to run on its own.
+- No tool-call noise filtering here (unlike `/recall <query>` and
+  `session-recall.sh`) — the orchestrator curates what goes into the
+  subagent prompt anyway; filter manually if a query pulls in noise.


### PR DESCRIPTION
## Summary

- First-time commit of the session-history hooks/skills set up in a prior session (previously local-only, blocked by the global dotfile `.gitignore`)
- Syncs 3 bugfixes from `~/wrk/common/skills/` (source of truth, commits `fcb268a`/`ba6e08f`/`84308f3`):
  - `session-recall.sh` — trim `.Content` before the tool-noise regex test and truncation
  - `session-recall/SKILL.md` — add `WebSearch` to the tool-noise regex alternation (was missing, inconsistent with the hook)
  - `session-end.sh` + `SKILL.md` — move today's replaced entry to the end of the list before the positional last-N trim, so a fresh write can never be silently dropped

## Test plan

- [x] `bash -n` passes on both hooks
- [x] Manually verified fix 1: a tool-call chunk with leading whitespace (`"\nBash{...}"`) is now correctly filtered by the jq pipeline (previously slipped through)
- [x] `bundle exec jekyll build` unaffected (no Jekyll-relevant files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)