### PR TITLE
Remove broken UK link from session-indexer project page

### DIFF
--- a/projects/session-indexer.md
+++ b/projects/session-indexer.md
@@ -9,8 +9,6 @@ lang_alt: /uk/projects/session-indexer/
 
 # session-indexer — Per-Project Semantic Session Recall for Claude Code
 
-[Те саме Українською](../session-indexer-ua)
-
 **Links:**
 
 - [GitHub](https://github.com/valpere/session-indexer)


### PR DESCRIPTION
## Summary

- Removes the "Те саме Українською" link from `projects/session-indexer.md` — it pointed to `/projects/session-indexer-ua/`, which doesn't exist (the UK page shares the same permalink `/projects/session-indexer/`, differentiated by `lang:`, not a separate URL)

## Test plan

- [x] `bundle exec jekyll build` passes
- [ ] `/projects/session-indexer/` renders without the dead link

🤖 Generated with [Claude Code](https://claude.com/claude-code)