### PR TITLE
fix-review: use gh pr diff instead of git merge-base diff

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -140,7 +140,7 @@ now_ms() {
 ## STEP 1: Build the Review Prompt
 
 ```bash
-DIFF=$(git diff -U10 $(git merge-base HEAD origin/${BASE_BRANCH})...HEAD)
+DIFF=$(gh pr diff "${PR_NUMBER}")
 ```
 
 ### Detect diff type
@@ -150,7 +150,7 @@ Almost all PRs in this repo touch only Markdown, YAML, SVG, or images — detect
 ```bash
 is_docs_only_diff() {
   local files
-  files=$(git diff --name-only "$(git merge-base HEAD origin/${BASE_BRANCH})...HEAD")
+  files=$(gh pr diff "${PR_NUMBER}" --name-only)
   [ -z "$files" ] && return 1
   while IFS= read -r f; do
     case "$f" in


### PR DESCRIPTION
## Summary

- Replaces the merge-base-based `git diff` in Step 1 with `gh pr diff "${PR_NUMBER}"` — the merge-base three-dot diff was empirically returning 0 bytes in some branch states, causing the skill to review an empty diff
- Also updates the docs-only-diff file-list detection to use `gh pr diff --name-only`
- This is the diff-fetching approach used successfully throughout manual `/fix-review` runs on PRs #76-80 this session

## Test plan

- [x] `bundle exec jekyll build` passes (skill doc change only, no site content affected)
- [x] Validated informally across 5 live `/fix-review` runs this session using this exact approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)