### PR TITLE
Retire deprecated Ollama models ahead of 2026-07-15 cutoff

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -149,10 +149,10 @@ Rules: 10-20 bullets total, Ukrainian for content, English for code/file names."
 
 try_opencode() {
   local models=(
-    "ollama/glm-5:cloud"
-    "ollama/kimi-k2.5:cloud"
-    "ollama/minimax-m2.5:cloud"
-    "ollama/qwen3-coder-next:cloud"
+    "ollama/glm-5.2:cloud"
+    "ollama/kimi-k2.7-code:cloud"
+    "ollama/minimax-m3:cloud"
+    "ollama/qwen3.5:cloud"
   )
   command -v opencode &>/dev/null || return 1
   for model in "${models[@]}"; do

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -13,7 +13,7 @@ reviewers:
       model: deepseek-v4-flash:cloud
       think: true
     round_2:
-      model: qwen3-coder-next:cloud
+      model: qwen3.5:cloud
       think: false
     round_3:
       model: gemma4:31b-cloud

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -143,7 +143,7 @@ Next session opens
 
 LLM fallback chain (Stop hook), both discovered in this project:
 1. `agy -p` — Gemini 3.5 Flash (Low/Medium/High) → Gemini 3.1 Pro (Low/High)
-2. `opencode run --format json` — `ollama/glm-5:cloud`, `ollama/kimi-k2.5:cloud`, `ollama/minimax-m2.5:cloud`, `ollama/qwen3-coder-next:cloud`
+2. `opencode run --format json` — `ollama/glm-5.2:cloud`, `ollama/kimi-k2.7-code:cloud`, `ollama/minimax-m3:cloud`, `ollama/qwen3.5:cloud`
 3. Raw transcript excerpt (fallback if both fail)
 
 Mempalace was removed from this project — `session-end`/`session-recall` are


### PR DESCRIPTION
## Summary

Ollama is retiring several cloud models on 2026-07-15. This project referenced two of them:

- `.claude/hooks/session-end.sh` — `glm-5:cloud` → `glm-5.2:cloud`, `qwen3-coder-next:cloud` → `qwen3.5:cloud` (plus a freshness bump for `kimi-k2.5:cloud`/`minimax-m2.5:cloud`, not retiring but stale vs. other projects' copies)
- `.claude/skills/fix-review/config.yaml` (round_2) — `qwen3-coder-next:cloud` → `qwen3.5:cloud`
- `.claude/skills/session-end/SKILL.md` — doc updated to match

All 4 replacement tags probed live against the local Ollama daemon (HTTP 200) before committing.

## Test plan

- [x] `bash -n .claude/hooks/session-end.sh` passes
- [x] All 4 new model tags return HTTP 200 from the local Ollama daemon
- [x] `bundle exec jekyll build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)