### PR TITLE
chore: gitignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ tmp/
 # Session recall — per-project, local-only context log/index
 .claude/session-log.md
 .claude/sessions.db
+
+# Claude Code local-only settings — never commit (per-machine hook wiring)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- ~/.gitignore_global's blanket dotfile-ignore (`.*`, `_*`) was commented out recently, so this project's `.gitignore` now needs to explicitly cover Claude Code's local-only settings file
- It was sitting untracked and exposed to a broad `git add -A`

## Test plan
- [ ] Verify `.claude/settings.local.json` no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)