### PR TITLE
chore: gitignore .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ tmp/
 
 # Claude Code local-only settings — never commit (per-machine hook wiring)
 .claude/settings.local.json
+
+# Playwright MCP scratch artifacts (console logs, page snapshots)
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Global dotfile-ignore blanket rule (`~/.gitignore_global`) was commented out, exposing Playwright MCP's local scratch artifacts (console logs, page snapshots) as untracked
- Branch note: this reuses the `chore-gitignore-settings-local` branch name from the already-merged #84 — GitHub deleted that branch on merge, this push recreated it with just the new commit on top. The diff below should show only the `.playwright-mcp/` addition since the settings.local.json line is already in `main`.

## Test plan
- [ ] Confirm the diff shows only `.playwright-mcp/` (not settings.local.json again)
- [ ] Verify `.playwright-mcp/` no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)