### PR TITLE
Minimize homepage visual noise: unify project thumbnails, quiet ticker

### DIFF
--- a/_sass/_pages.scss
+++ b/_sass/_pages.scss
@@ -1,31 +1,31 @@
 /* ── Tech tape marquee ── */
 .ed-tape {
-  background: var(--brand-yellow);
-  border-top: 1.5px solid var(--ink);
-  border-bottom: 1.5px solid var(--ink);
+  background: var(--paper);
+  border-top: 1px solid var(--brand-border);
+  border-bottom: 1px solid var(--brand-border);
   overflow: hidden;
   position: relative;
 }
 
 .ed-tape-inner {
   display: flex;
-  gap: 40px;
-  padding: 18px 0;
+  gap: 32px;
+  padding: 11px 0;
   white-space: nowrap;
   animation: tape 50s linear infinite;
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 500;
   letter-spacing: 0.02em;
-  color: var(--ink);
+  color: var(--muted);
 
-  span { display: inline-flex; align-items: center; gap: 40px; }
+  span { display: inline-flex; align-items: center; gap: 32px; }
 
   .tape-dot {
-    width: 8px;
-    height: 8px;
-    background: var(--ink);
-    border-radius: 2px;
+    width: 5px;
+    height: 5px;
+    background: var(--brand-yellow-dark);
+    border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
   }
@@ -126,8 +126,14 @@
     border-bottom: 1.5px solid var(--ink);
     background: var(--paper-2);
 
-    img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    img {
+      width: 100%; height: 100%; object-fit: cover; display: block;
+      filter: grayscale(0.85) contrast(1.05);
+      transition: filter 0.3s ease;
+    }
   }
+
+  &:hover .proj-thumb img { filter: grayscale(0); }
 
   &.ed-proj--hero .proj-thumb { aspect-ratio: 16 / 10; }
 


### PR DESCRIPTION
## Summary

Homepage design review — the "Featured Projects" grid and tech-stack ticker were the two biggest contributors to a cluttered first impression:

- **Project thumbnails**: 6 completely unrelated visual styles side by side (dark node diagram, colorful icon illustration, photo collage, dense Ukrainian CRM screenshot, bold yellow banner, line-icon infographic). Fixed with a grayscale filter by default, full color restored on hover — the grid now reads as one system, color becomes an interactive reward instead of front-loaded noise.
- **Tech tape ticker**: was a solid full-bleed bright-yellow marquee immediately below the hero, competing hard for attention. Switched to a muted paper background, small yellow dots instead of a solid fill, smaller text/padding.

Confirmed NOT to touch (investigated, ruled out as false leads):
- Ragged card heights — already constrained by `aspect-ratio` + `object-fit: cover`, the apparent unevenness is just the `ed-proj--hero` 2-row span, which is intentional
- Blog category tags — verified they're a single consistent green, not the multi-color mess they appeared to be at thumbnail size
- Blank featured-post image block — deliberate brand-color fallback when a post has no `image:`, not a bug

## Test plan

- [x] `bundle exec jekyll build` passes
- [x] Verified live via Chromium/CDP: thumbnails render grayscale by default, full color on hover (confirmed via programmatic hover + screenshot)
- [x] Verified ticker renders as a quiet, muted strip instead of a solid yellow band

🤖 Generated with [Claude Code](https://claude.com/claude-code)