### PR TITLE
Skills/workflow hygiene: gitignore gaps, rest.sh sync, fix-review retry, housekeeping skill

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -218,7 +218,7 @@ PROMPT=$(printf '%s' "$PROMPT_TEMPLATE" | sed "s|{DIFF}|$(printf '%s' "$DIFF" | 
 RUN_DIR=$(mktemp -d -t fix-review-XXXX)
 WALL_START_MS=$(now_ms)
 
-REVIEW_SYSTEM_MSG="You are a senior code reviewer. Your entire response MUST be a raw JSON array — nothing else. Start with [ and end with ]. No prose, no markdown fences, no explanations before or after. If there are no issues output exactly: []"
+REVIEW_SYSTEM_MSG="You are a senior code reviewer. Your entire response MUST be a raw JSON array — nothing else. Start with [ and end with ]. No prose, no markdown fences, no explanations before or after. Report at most 8 findings, most severe first; each body under 30 words. Do not include informational or 'no action needed' entries — only real issues. If there are no issues output exactly: []"
 
 export PROVIDER REVIEWER_BLOCK API_URL API_KEY PROMPT RUN_DIR \
        MODEL_R1 MODEL_R2 MODEL_R3 REVIEW_SYSTEM_MSG
@@ -235,6 +235,23 @@ run_round() {
     '{model:$m,messages:[{role:"system",content:$sys},{role:"user",content:$user}],stream:false,think:$think}')
   response=$(rest_post "$API_URL" "$payload" "$API_KEY") \
     || response='{"_error":"rest_post_failed"}'
+
+  # Empty-content retry: a thinking-enabled model (round_1 here runs
+  # think:true — deepseek-v4-flash:cloud) can burn its whole budget on
+  # hidden thinking and return 200 + empty content on a large diff. Retry
+  # once with a tighter num_predict cap before accepting 0 findings.
+  if ! printf '%s' "$response" | jq -e '._error' >/dev/null 2>&1; then
+    local content; content=$(printf '%s' "$response" | jq -r '.message.content // empty')
+    if [ -z "$(printf '%s' "$content" | tr -d '[:space:]')" ]; then
+      echo "warn: round ${n} (${model}) returned empty content — retrying once with a tighter cap" >&2
+      payload=$(jq -n --arg m "$model" --arg sys "$REVIEW_SYSTEM_MSG" \
+        --arg user "$PROMPT" --argjson think "$think" \
+        '{model:$m,messages:[{role:"system",content:$sys},{role:"user",content:$user}],stream:false,think:$think,options:{num_predict:2000}}')
+      response=$(rest_post "$API_URL" "$payload" "$API_KEY") \
+        || response='{"_error":"rest_post_failed"}'
+    fi
+  fi
+
   r_end=$(now_ms)
   printf '%s' "$response" > "$RUN_DIR/round_${n}.raw.json"
   pt=$(printf '%s' "$response" | jq -r '.prompt_eval_count // empty')

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: housekeeping
+description: "Recurring repo health check for valpere.github.io. Runs universal hygiene checks plus Jekyll-specific checks and outputs a pass/fail table. Usage: /housekeeping"
+---
+
+# Skill: /housekeeping
+# Repo Health Check — valpere.github.io
+
+---
+
+## OVERVIEW
+
+```
+/housekeeping  →  run checks  →  Markdown table: Check | Status | Detail
+                              →  Summary: N passed, M failed
+```
+
+Read-only. Never modifies files, never commits, never opens a PR.
+Run any time for a hygiene snapshot. Any FAIL = exit signal to fix before shipping.
+
+Universal checks 1-5 mirror `~/wrk/common/skills/housekeeping/SKILL.md`
+(debug-output, tracked-backup, and layout-drift checks omitted — not
+relevant for a Jekyll content site with no `src/`/`backup/`/`../context/`
+convention). Checks 6-10 are Jekyll-specific.
+
+---
+
+## UNIVERSAL CHECKS
+
+### Check 1 — Stale Local Branches
+
+**Goal:** ≤ 10 local branches after pruning remote-tracking refs.
+
+```bash
+git remote prune origin 2>&1 | tail -3
+LOCAL_COUNT=$(git branch | grep -v '^\*' | wc -l | tr -d ' ')
+```
+
+**Pass:** `LOCAL_COUNT <= 10`
+**Fail:** "N local branches — prune merged ones"
+
+Cleanup tip:
+```bash
+git branch --merged main | grep -v 'main\|^\*'
+# delete with: git branch -d <branch>
+```
+
+---
+
+### Check 2 — Tracked .env File
+
+**Goal:** `.env` must not be tracked by git (would leak secrets).
+
+```bash
+TRACKED=$(git ls-files .env 2>/dev/null)
+```
+
+**Pass:** empty result
+**Fail:** "`.env` is tracked — add to .gitignore and run `git rm --cached .env`"
+
+---
+
+### Check 3 — TODO/FIXME Count (informational)
+
+**Goal:** Report count. No threshold — visibility only.
+
+```bash
+COUNT=$(grep -rE "TODO|FIXME" \
+  --include="*.md" --include="*.yml" --include="*.yaml" --include="*.scss" \
+  --exclude-dir=_site --exclude-dir=.jekyll-cache --exclude-dir=.git --exclude-dir=.claude \
+  . 2>/dev/null | wc -l | tr -d ' ')
+```
+
+**Status:** Always `INFO`.
+**Detail:** "N TODO/FIXME comments" — append " (consider a cleanup sprint)" if > 20.
+
+This check never contributes to the failed count.
+
+---
+
+### Check 4 — CLAUDE.md Key Files Exist
+
+**Goal:** files explicitly listed under a "Key Files" / "Ключові файли"
+section of `CLAUDE.md` should actually exist on disk.
+
+```bash
+MISSING=""
+if [ -f CLAUDE.md ]; then
+  MISSING=$(awk '
+    /^##.*[Kk]ey [Ff]iles|^##.*[Кк]лючов.*файл/ {in_section=1; next}
+    /^##/ && in_section {in_section=0}
+    in_section
+  ' CLAUDE.md | grep -oE '`[^`]+`' | tr -d '`' | while read f; do
+    case "$f" in
+      */*|*.md|*.yml|*.yaml|*.scss|*.html)
+        [ -e "$f" ] || echo "$f"
+        ;;
+    esac
+  done)
+fi
+```
+
+**Pass:** all listed files exist (or no Key Files section).
+**Fail:** list missing paths — likely doc drift after a rename/delete.
+**Skip:** no `CLAUDE.md` at repo root, or no Key Files section.
+
+---
+
+### Check 5 — Skill Temp Dir Accumulation (informational)
+
+**Goal:** report `/tmp/<skill>-*` directories older than 7 days from
+interactive skill runs (`fix-review`, etc).
+
+```bash
+COUNT=$(find /tmp -maxdepth 1 -type d -mtime +7 \
+  -name 'fix-review-*' \
+  2>/dev/null | wc -l | tr -d ' ')
+```
+
+**Status:** Always `INFO`.
+**Detail:** "N stale skill temp dirs in /tmp" — append " (rm -rf /tmp/fix-review-* to clean)" if > 5.
+
+This check never contributes to the failed count.
+
+---
+
+## JEKYLL-SPECIFIC CHECKS
+
+### Check 6 — Jekyll Build Health
+
+**Goal:** the site builds cleanly.
+
+```bash
+BUILD_OUT=$(bundle exec jekyll build 2>&1)
+BUILD_EXIT=$?
+LIQUID_ISSUES=$(printf '%s' "$BUILD_OUT" | grep -E "Liquid Warning|Liquid Exception")
+```
+
+**Pass:** `BUILD_EXIT == 0` and no `Liquid Warning`/`Liquid Exception` lines.
+**Fail:** print the Liquid warning/exception lines, or the build's non-zero exit.
+**Note:** ignore SASS deprecation warnings — they come from the `minima`
+theme, not this site's own code.
+
+---
+
+### Check 7 — Gemfile.lock Sync
+
+**Goal:** `Gemfile.lock` matches `Gemfile`.
+
+```bash
+bundle check >/dev/null 2>&1
+BUNDLE_OK=$?
+```
+
+**Pass:** `BUNDLE_OK == 0`
+**Fail:** "Gemfile.lock out of sync — run `bundle install`"
+
+---
+
+### Check 8 — og:image Frontmatter Must Be a String
+
+**Goal:** no post/page sets `image:` (or `og_image:`) to a YAML hash —
+jekyll-seo-tag 2.8.0 breaks the `<meta property="og:image">` tag on a
+hash value instead of a plain string path.
+
+```bash
+OFFENDERS=$(grep -rln "^image:\s*{" --include="*.md" \
+  --exclude-dir=_site --exclude-dir=.jekyll-cache . 2>/dev/null)
+```
+
+**Pass:** empty result.
+**Fail:** list offending files — fix by replacing the hash with a plain
+string path (see `.claude/skills/fix-review/docs-prompt.txt` for the
+documented failure mode).
+
+---
+
+### Check 9 — Bilingual Pairing (informational)
+
+**Goal:** report `_posts/*.md` entries without a `-uk.md` twin, or
+`-uk.md` entries without a base-language twin. Asymmetry can be
+intentional (EN-only or UK-only pieces) — this is visibility only,
+never a failure.
+
+```bash
+MISSING_UK=""
+MISSING_BASE=""
+for f in _posts/*.md; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    *-uk.md)
+      base="${f%-uk.md}.md"
+      [ -f "$base" ] || MISSING_BASE="$MISSING_BASE $f"
+      ;;
+    *)
+      twin="${f%.md}-uk.md"
+      [ -f "$twin" ] || MISSING_UK="$MISSING_UK $f"
+      ;;
+  esac
+done
+```
+
+**Status:** Always `INFO`.
+**Detail:** "N EN posts without a UK twin" / "N UK posts without a base twin" — list up to 5 filenames, then "+ N more".
+
+This check never contributes to the failed count.
+
+---
+
+### Check 10 — Broken Internal Links (best-effort)
+
+**Goal:** flag `[text](/some/path/)`-style internal links that don't
+resolve to any file in the repo.
+
+```bash
+LINKS=$(grep -rohE '\]\([/][a-zA-Z0-9/_.-]+/?\)' \
+  --include="*.md" \
+  --exclude-dir=_site --exclude-dir=.jekyll-cache --exclude-dir=.claude \
+  . 2>/dev/null | grep -oE '/[a-zA-Z0-9/_.-]+/?' | sort -u)
+
+BROKEN=""
+for link in $LINKS; do
+  path="${link#/}"
+  path="${path%/}"
+  # try as directory index, direct file, or .md source
+  if [ -f "${path}/index.md" ] || [ -f "${path}.md" ] || [ -f "${path}" ] || [ -d "$path" ]; then
+    continue
+  fi
+  BROKEN="$BROKEN $link"
+done
+```
+
+**Pass:** empty `BROKEN` list.
+**Fail:** list broken-looking links (up to 10, then "+ N more") — treat
+as "worth a manual look," not a final verdict.
+**Known limitation:** does not understand Jekyll's permalink rewrite
+(`_posts/YYYY-MM-DD-slug.md` → `/blog/YYYY/MM/DD/slug/`), so it
+under-reports rather than over-reports. **Must exclude `.claude/`** —
+without it, example links inside skill docs (like this file) produce
+false positives.
+
+---
+
+## OUTPUT FORMAT
+
+```
+## /housekeeping — Repo Health Report
+
+| Check | Status | Detail |
+|-------|--------|--------|
+| Stale local branches | PASS | 6 local branches |
+| Tracked .env | PASS | — |
+| TODO/FIXME count | INFO | 4 TODO/FIXME comments |
+| CLAUDE.md key files | SKIP | no Key Files section |
+| Skill temp dirs | INFO | 2 stale skill temp dirs in /tmp |
+| Jekyll build health | PASS | — |
+| Gemfile.lock sync | PASS | — |
+| og:image frontmatter | PASS | — |
+| Bilingual pairing | INFO | 5 EN posts without a UK twin |
+| Broken internal links | PASS | — |
+
+**8 passed, 0 failed** (2 informational, 1 skipped)
+```
+
+Status values:
+- `PASS` — check succeeded
+- `FAIL` — check failed (must be addressed)
+- `INFO` — informational only, never counted as failed
+- `SKIP` — could not run (missing tools, no artifacts)
+
+Summary: `N passed, M failed` — with optional `(K informational, J skipped)`.
+
+---
+
+## RULES
+
+1. **Read-only** — never modify files, commit, push, or open a PR.
+2. **Run from repo root** — all paths relative to repository root.
+3. **INFO checks never count as failures.**
+4. **SKIP is not failure** — a skipped check doesn't increment failed count.
+5. **Graceful degradation** — if a tool is unavailable, mark check SKIP and continue.
+6. **No auto-fix** — this skill reports; fix findings manually or via the appropriate PR workflow.
+7. **Exit signal** — if any check is FAIL, end with: "Run /housekeeping again after fixing the issues above."

--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -72,6 +72,17 @@ ollama_content() {
   printf '%s' "$1" | jq -r '.message.content // empty'
 }
 
+# Like ollama_payload_system but sets think:false (top-level field on
+# /api/chat, not inside options) and a capped num_predict. Without this,
+# reasoning-capable cloud models (deepseek, kimi, etc.) can burn their whole
+# token budget on hidden thinking and return empty content on large prompts.
+ollama_payload_system_no_think() {
+  local num_predict="${4:-4000}"
+  jq -n --arg model "$1" --arg sys "$2" --arg prompt "$3" --argjson np "$num_predict" \
+    '{model:$model, messages:[{role:"system",content:$sys},{role:"user",content:$prompt}],
+      stream:false, think:false, options:{num_predict:$np}}'
+}
+
 # ---------------------------------------------------------------------------
 # OpenRouter — /api/v1/chat/completions (OpenAI-compatible)
 # Response: { "choices": [{ "message": { "content": "..." } }] }
@@ -125,11 +136,13 @@ chat_payload_system() {
 }
 
 # Like chat_payload_system but suppresses reasoning tokens on thinking models.
-# Use for DeepSeek-family models on OpenRouter; no-op on Ollama.
+# Use for DeepSeek-family models on OpenRouter, or any reasoning-capable
+# model on Ollama (deepseek, kimi, etc. via /api/chat's top-level think field).
+# Optional 5th arg: num_predict cap, Ollama branch only (default 4000).
 chat_payload_system_no_think() {
   case "$1" in
     openrouter) openrouter_payload_system_no_think "$2" "$3" "$4" ;;
-    *)          ollama_payload_system              "$2" "$3" "$4" ;;
+    *)          ollama_payload_system_no_think      "$2" "$3" "$4" "$5" ;;
   esac
 }
 

--- a/.claude/skills/session-recall/SKILL.md
+++ b/.claude/skills/session-recall/SKILL.md
@@ -130,6 +130,9 @@ Limitations:
   don't include the `Skill` tool — a spawned subagent can't invoke `/recall`
   or this skill itself mid-task. This section is for the orchestrator to run
   *before* spawning, not for the subagent to run on its own.
+  Same root cause as the general agent/skill boundary documented in
+  `~/wrk/common/skills/README.md`'s design principles — see that note
+  before assuming any skill will auto-trigger inside a subagent.
 - No tool-call noise filtering here (unlike `/recall <query>` and
   `session-recall.sh`) — the orchestrator curates what goes into the
   subagent prompt anyway; filter manually if a query pulls in noise.

--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,14 @@ tmp/
 # Session recall — per-project, local-only context log/index
 .claude/session-log.md
 .claude/sessions.db
+.claude/sessions.db-shm
+.claude/sessions.db-wal
 
 # Claude Code local-only settings — never commit (per-machine hook wiring)
 .claude/settings.local.json
+
+# Claude Code worktree state — runtime per machine
+.worktrees/
 
 # Playwright MCP scratch artifacts (console logs, page snapshots)
 .playwright-mcp/


### PR DESCRIPTION
## Summary
Sourced from a foreign-project hygiene pass (`~/wrk/common`), each item verified against current repo state before applying. All touch `.claude/` — confirmed with the user before proceeding per the standing rule requiring explicit approval for `.claude/` changes.

- **`.gitignore`**: cover `sessions.db-shm`/`-wal` WAL sidecars and root-level `.worktrees/` — both were unmatched
- **`.claude/skills/lib/rest.sh`**: full sync to library version, fixes a dormant bug where `chat_payload_system_no_think()`'s Ollama branch called the wrong helper (currently unused by fix-review's inline payload, but now consistent)
- **`.claude/skills/session-recall/SKILL.md`**: add missing xref to the shared agent/skill boundary design note
- **`.claude/skills/fix-review/SKILL.md`**: retry once on empty content from `round_1`'s thinking-enabled model (`deepseek-v4-flash:cloud`, `think:true`) before accepting 0 findings — same failure mode already fixed in lance-agent (PR #201); also caps `REVIEW_SYSTEM_MSG` at 8 findings to match the library prompt
- **`.claude/skills/housekeeping/SKILL.md`** (new): universal hygiene checks (stale branches, tracked `.env`, TODO/FIXME, CLAUDE.md key files, skill temp dirs) + Jekyll-specific checks (build health, Gemfile.lock sync, `og:image` frontmatter, bilingual pairing, broken internal links)

`.claude/settings.local.json` (unanchored hook paths → `$CLAUDE_PROJECT_DIR`) is gitignored and applied directly — not part of this diff.

## Test plan
- [x] `.gitignore` sanity script: 5 previously-unmatched paths now `OK ignored`, 3 tracked skill files stay `OK tracked`
- [x] `rest.sh` diff against library — identical; `bash -n` syntax check passes
- [x] `fix-review/SKILL.md`'s patched `run_round()` extracted and syntax-checked standalone — passes
- [x] All 10 `/housekeeping` checks run live during authoring; caught and fixed a self-matching bug (Check 3 grep matched its own doc text) before commit
- [x] `bundle exec jekyll build` passes