### PR TITLE
test: fix-review external_agents failover verification (throwaway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 Personal portfolio site for Valentyn Solomko — [https://valpere.github.io](https://valpere.github.io)
+<!-- fix-review external_agents migration test PR — will be closed without merging -->


### PR DESCRIPTION
Throwaway PR to exercise the /fix-review failover path after migrating
this project's config.yaml/SKILL.md from the old `reviewers.cli` tier
to the canonical `reviewers.external_agents` pattern.

Will be closed without merging once the test confirms the cascade
works and correctly names the tool used.