### PR TITLE
fix(fix-review): add missing agy adapter to external_agents

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -273,7 +273,7 @@ run_external_agent_round() {
   printf '%s\n%s\nnull null\n' "$tool" "$((r_end - r_start))" > "$RUN_DIR/round_${n}.meta"
 }
 export -f run_round run_external_agent_round
-export -f run_external_agent agent_cursor_agent agent_omp agent_codex agent_opencode agent_kilo
+export -f run_external_agent agent_cursor_agent agent_agy agent_omp agent_codex agent_opencode agent_kilo
 
 if [ "$ACTIVE_PROVIDER" = "external_agents" ]; then
   PROMPT_FILE="$RUN_DIR/prompt.txt"

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -40,6 +40,7 @@ reviewers:
   # invocation/output-format compatibility.
   external_agents:
     - { tool: cursor-agent, model: auto }
+    - { tool: agy, model: "Gemini 3.5 Flash (Low)" }
     - { tool: omp }
     - { tool: codex }
     - { tool: opencode, model: "opencode/nemotron-3-ultra-free" }

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -35,6 +35,17 @@ agent_cursor_agent() {
     | jq -r '.result // empty'
 }
 
+agent_agy() {
+  local model="$1" prompt_file="$2"
+  # Unlike every other adapter here, the prompt MUST be a positional
+  # argument, not stdin/file-ref — verified 2026-07-30. --prompt is an
+  # alias for the --print boolean flag, not a value-taking option; the
+  # actual prompt text goes after -p as a trailing positional argument.
+  agy -p "$(cat "$prompt_file")" --model "${model:-Gemini 3.5 Flash (Low)}" \
+    --mode plan --output-format json 2>/dev/null \
+    | jq -r '.response // empty'
+}
+
 agent_omp() {
   local model="$1" prompt_file="$2"
   # omp's own "@file" syntax for message content (not stdin).
@@ -79,6 +90,7 @@ run_external_agent() {
   local tool="$1" model="$2" prompt_file="$3"
   case "$tool" in
     cursor-agent) agent_cursor_agent "$model" "$prompt_file" ;;
+    agy)          agent_agy          "$model" "$prompt_file" ;;
     omp)          agent_omp          "$model" "$prompt_file" ;;
     codex)        agent_codex        "$model" "$prompt_file" ;;
     opencode)     agent_opencode     "$model" "$prompt_file" ;;


### PR DESCRIPTION
## Summary
- Adds the missing `agy` adapter to the `external_agents` tier-2 reviewer cascade, per the shared audit at `~/wrk/common/tmp/fix-review-agy-rollout-shared.md`.
- Root cause: `agy --prompt "text"` doesn't work as expected — `--prompt` is just an alias for the `--print` boolean flag, not a value-taking option, so the prompt text was silently dropped. Fix: pass the prompt as a bare positional argument after `-p`.
- Patch applied exactly as specified in the audit doc (`agent_agy()` in `lib/agents.sh`, dispatcher registration, `config.yaml` entry in position 2).
- No `pricing:` change — this project's `config.yaml` has no `pricing:` map to amend.

## Test plan
- [x] `bash -n .claude/skills/lib/agents.sh` — syntax OK
- [x] `yq -c '.reviewers.external_agents[]' config.yaml` — `agy` present with correct model
- [x] `agy --help` re-checked live — `--prompt`/`-p` signature still matches the doc's root-cause explanation
- [x] Live smoke test: called `agent_agy()` directly with a real prompt file, got the expected `[]` response back

🤖 Generated with [Claude Code](https://claude.com/claude-code)