### PR TITLE
fix(fix-review): stop misapplying blog-post rules to portfolio pages, realign cloud model trio

### DIFF
--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -8,15 +8,21 @@
 provider: ollama
 
 reviewers:
+  # Matches the canonical fix-review recommendation in
+  # ~/wrk/common/common/ollama-cloud-coding-models.md (glm-5.1 → deepseek-v4-flash
+  # → kimi-k2.7-code) — this project had drifted to a different trio;
+  # realigned 2026-08-19 after observing deepseek-v4-flash produce noisy
+  # self-contradictory "no issue" findings when run as R1 with think:true
+  # on a docs-only diff (PR #103).
   ollama_cloud:
     round_1:
-      model: deepseek-v4-flash:cloud
+      model: glm-5.1:cloud
       think: true
     round_2:
-      model: qwen3.5:cloud
+      model: deepseek-v4-flash:cloud
       think: false
     round_3:
-      model: gemma4:31b-cloud
+      model: kimi-k2.7-code:cloud
       think: false
 
   ollama_local:
@@ -33,11 +39,13 @@ reviewers:
   # only (lib/agents.sh) — replaces the old `cli:` block, which ran `agy`
   # with --dangerously-skip-permissions and `codex` with
   # --dangerously-bypass-approvals-and-sandbox (full write/bypass access
-  # for a reviewer that only needs to read). `agy` and `gemini` dropped:
-  # agy was evaluated upstream and excluded (explores the filesystem
-  # instead of answering, not a prompt-wording issue — verified
-  # 2026-07-29 in ~/wrk/common); gemini was never evaluated for read-only
-  # invocation/output-format compatibility.
+  # for a reviewer that only needs to read). `agy` was initially excluded
+  # (looked like it explored the filesystem instead of answering) but
+  # that was a testing mistake, not a real limitation — root cause found
+  # 2026-07-30 (--prompt is an alias for the --print boolean flag, not a
+  # value-taking option) and re-added in PR #101 with the correct
+  # positional-argument invocation. `gemini` stays dropped — never
+  # evaluated for read-only invocation/output-format compatibility.
   external_agents:
     - { tool: cursor-agent, model: auto }
     - { tool: agy, model: "Gemini 3.5 Flash (Low)" }

--- a/.claude/skills/fix-review/docs-prompt.txt
+++ b/.claude/skills/fix-review/docs-prompt.txt
@@ -3,11 +3,20 @@ You are a senior Jekyll/content engineer reviewing a pull request on **valpere.g
 Site conventions:
 - Posts: `_posts/YYYY-MM-DD-<slug>.md` (EN) + `_posts/YYYY-MM-DD-<slug>-uk.md` (UK)
 - Post permalink format: `/blog/YYYY/MM/DD/<slug>/`
+- Post required frontmatter: `layout`, `title`, `date`, `permalink`, `lang` (both EN and UK post pages carry `lang:`)
 - Images: `assets/images/posts/<slug>/<description>-<sequence>-<width>x<height>.<ext>` (SVG needs no dimensions)
-- Portfolio images: `portfolio/assets/images/<client-name>/`
 - Project images: `projects/assets/images/<project-name>/`
 - `og:image` / `image:` frontmatter value must be a plain string path — NOT a hash (jekyll-seo-tag 2.8.0 breaks on hash)
-- Internal links must be site-relative (`/projects/`, `/blog/`) — never hardcoded `https://valpere.github.io/...`
+- Internal links must be site-relative (`/projects/`, `/blog/`) — never hardcoded `https://valpere.github.io/...`. Links to a different domain (e.g. `https://github.com/...`) are correctly absolute — do not flag those.
+
+Portfolio pages follow a DIFFERENT, deliberately simpler convention — do not apply the post rules above to anything under `portfolio/`:
+- Portfolio pages: `portfolio/<slug>.md` (EN) + `portfolio/<slug>-ua.md` (UK) — note the suffix is `-ua`, not `-uk` like posts.
+- Portfolio required frontmatter: `layout: portfolio-item`, `title`, `permalink` on both pages. The `-ua.md` page additionally carries `lang: uk` and `lang_alt:` — the EN page has NEITHER `lang` NOR `lang_alt`. This is intentional, not a missing field.
+- `lang_alt` on the `-ua.md` page is set to the page's OWN permalink (identical value), not a different URL — both language pages share one canonical permalink by design. Do not flag this as "should point elsewhere."
+- Portfolio pages do NOT use `date` or `excerpt` frontmatter at all, on either language page. Do not flag these as missing.
+- Only the EN portfolio page carries `image:` frontmatter; the `-ua.md` page has no `image:` field (both languages share one hero image via `_data/portfolio.yml`'s `hero_image` key). Do not flag the UA page for a missing `image:`.
+- Portfolio hero images: `portfolio/assets/images/<slug>/<slug>-<lang>.png` (e.g. `tumanomir-en.png`, `fix-review-en.png`) — this is the actual naming convention; do NOT apply the blog posts' `<description>-<sequence>-<width>x<height>` pattern to portfolio images.
+- `_data/portfolio.yml` intentionally repeats each entry's `permalink`, matching the corresponding page's frontmatter `permalink` exactly — that duplication is the lookup key `_layouts/portfolio-item.html` uses (`site.data.portfolio | where: "permalink", page.permalink`), not a routing conflict. Do not flag it.
 
 {PROJECT_CONTEXT}
 
@@ -20,11 +29,14 @@ Review the following git diff. Use this priority pyramid — flag lower layers f
                                      Liquid errors, SCSS syntax, `image:` path points to a file not added in
                                      this diff, `og:image` is a hash instead of a string, `date:` not
                                      YYYY-MM-DD, wrong `permalink:` format.
-  1 (base)— Architecture          → Missing required frontmatter fields (`layout`, `title`, `date`,
-                                     `permalink`, `lang`), bilingual pair missing (EN post without
-                                     matching `-uk.md` or vice versa), image filename violates naming
-                                     convention, image file added but not referenced in any post,
-                                     hardcoded absolute URLs in content links.
+  1 (base)— Architecture          → For blog posts (`_posts/`): missing required frontmatter fields
+                                     (`layout`, `title`, `date`, `permalink`, `lang`), bilingual pair
+                                     missing (EN post without matching `-uk.md` or vice versa), image
+                                     filename violates the posts' naming convention. For portfolio pages
+                                     (`portfolio/`): apply the portfolio-specific rules above instead —
+                                     do not reuse the post rules here. For both: image file added but
+                                     not referenced anywhere in this diff, hardcoded absolute URLs to
+                                     valpere.github.io in content links (external-domain links are fine).
 
 Return ONLY a JSON array — no prose, no markdown fences, just the raw JSON.
 Each item must have exactly these fields:


### PR DESCRIPTION
## Summary
Third occurrence of the same false-positive class across PRs #97/#102/#103: `docs-prompt.txt` only described blog-post frontmatter conventions, so review models kept flagging `portfolio/` pages for missing `date`/`lang`(EN)/`excerpt`/`image`(UA), a "wrong" `lang_alt`, "wrong" image naming, and a "routing collision" in `portfolio.yml` — all contradicted by the site's own existing convention.

- **`docs-prompt.txt`**: added an explicit portfolio-pages convention block and scoped the layer-1 architecture rule to say which checks apply to posts vs. portfolio pages, instead of one blanket list.
- **`config.yaml`**: realigned the cloud `round_1/2/3` trio to the canonical recommendation in `~/wrk/common/common/ollama-cloud-coding-models.md` (`glm-5.1 → deepseek-v4-flash → kimi-k2.7-code`) — this project had drifted to a different trio. Also moved `deepseek-v4-flash` from R1 (`think:true`) to R2 (`think:false`) after observing it produce noisy, self-contradictory "no issue" findings in that role.
- **`config.yaml`**: fixed a stale comment claiming `agy` was dropped from `external_agents` — it was re-added correctly in PR #101, the comment just never got updated.

## Test plan
- [x] `yq` validates `config.yaml`
- [x] Probed all 3 new cloud models live — all respond
- [x] Re-ran all 3 models against PR #103's diff (10 false positives under the old prompt/models) with the new prompt: **0 findings from all 3 models**

🤖 Generated with [Claude Code](https://claude.com/claude-code)